### PR TITLE
Deprecated client deleteFolder()

### DIFF
--- a/packages/cms-cli/commands/remove.js
+++ b/packages/cms-cli/commands/remove.js
@@ -1,6 +1,4 @@
-const path = require('path');
-
-const { deleteFile, deleteFolder } = require('@hubspot/cms-lib/api/fileMapper');
+const { deleteFile } = require('@hubspot/cms-lib/api/fileMapper');
 const { loadConfig } = require('@hubspot/cms-lib');
 const { logger } = require('@hubspot/cms-lib/logger');
 const {
@@ -44,39 +42,18 @@ function configureRemoveCommand(program) {
 
       trackCommandUsage(COMMAND_NAME, {}, portalId);
 
-      const ext = path.extname(hsPath);
-
-      // Note: module directories (e.g. Foo.module) are treated like files
-      if (!ext) {
-        deleteFolder(portalId, hsPath)
-          .then(() => {
-            logger.log(`Deleted "${hsPath}" from portal ${portalId}`);
+      try {
+        await deleteFile(portalId, hsPath);
+        logger.log(`Deleted "${hsPath}" from portal ${portalId}`);
+      } catch (error) {
+        logger.error(`Deleting "${hsPath}" from portal ${portalId} failed`);
+        logApiErrorInstance(
+          error,
+          new ApiErrorContext({
+            portalId,
+            request: hsPath,
           })
-          .catch(error => {
-            logger.error(`Deleting "${hsPath}" from portal ${portalId} failed`);
-            logApiErrorInstance(
-              error,
-              new ApiErrorContext({
-                portalId,
-                request: hsPath,
-              })
-            );
-          });
-      } else {
-        deleteFile(portalId, hsPath)
-          .then(() => {
-            logger.log(`Deleted "${hsPath}" from portal ${portalId}`);
-          })
-          .catch(error => {
-            logger.error(`Deleting "${hsPath}" from portal ${portalId} failed`);
-            logApiErrorInstance(
-              error,
-              new ApiErrorContext({
-                portalId,
-                request: hsPath,
-              })
-            );
-          });
+        );
       }
     });
 

--- a/packages/cms-lib/api/fileMapper.js
+++ b/packages/cms-lib/api/fileMapper.js
@@ -4,6 +4,7 @@ const contentDisposition = require('content-disposition');
 const http = require('../http');
 const { getCwd } = require('../path');
 const { getAndLoadConfigIfNeeded, getPortalConfig } = require('../lib/config');
+const { logger } = require('../logger');
 
 const FILE_MAPPER_API_PATH = 'content/filemapper/v1';
 
@@ -115,7 +116,7 @@ async function download(portalId, filepath, options = {}) {
 }
 
 /**
- * Delete file by path
+ * Delete a file or folder by path
  *
  * @async
  * @param {number} portalId
@@ -133,6 +134,7 @@ async function deleteFile(portalId, filePath, options = {}) {
 /**
  * Delete folder by path
  *
+ * @deprecated since 1.0.1 - use `deleteFile()` instead.
  * @async
  * @param {number} portalId
  * @param {string} folderPath
@@ -140,6 +142,9 @@ async function deleteFile(portalId, filePath, options = {}) {
  * @returns {Promise}
  */
 async function deleteFolder(portalId, folderPath, options = {}) {
+  logger.warn(
+    '`cms-lib/api/fileMapper#deleteFolder()` is deprecated. Use `cms-lib/api/fileMapper#deleteFile()` instead.'
+  );
   return http.delete(portalId, {
     uri: `${FILE_MAPPER_API_PATH}/delete/folder/${folderPath}`,
     ...options,


### PR DESCRIPTION
The API endpoint `DELETE content/filemapper/v1/delete/folder/:path` is deprecated.
The endpoint `DELETE content/filemapper/v1/delete/:path` can now be used for both file and folder paths.