### PR TITLE
Corrected module src/dest validation

### DIFF
--- a/packages/cms-cli/commands/upload.js
+++ b/packages/cms-cli/commands/upload.js
@@ -93,7 +93,10 @@ function configureUploadCommand(program) {
         portalId
       );
 
-      const srcDestIssues = await validateSrcAndDestPaths(src, dest);
+      const srcDestIssues = await validateSrcAndDestPaths(
+        { isLocal: true, path: src },
+        { isHubSpot: true, path: dest }
+      );
       if (srcDestIssues.length) {
         srcDestIssues.forEach(({ message }) => logger.error(message));
         process.exit(1);

--- a/packages/cms-lib/__tests__/modules.js
+++ b/packages/cms-lib/__tests__/modules.js
@@ -16,11 +16,6 @@ const moduleFolderPaths = folderPaths.reduce((acc, folder) => {
   );
 }, []);
 
-const filePaths = [...folderPaths, ...moduleFolderPaths].reduce(
-  (acc, folder) => acc.concat(path.join(folder, 'file.js')),
-  []
-);
-
 const isLocal = true;
 const isHubSpot = true;
 const emptyLocal = { isLocal, path: '' };
@@ -32,20 +27,56 @@ jest.mock('../lib/walk', () => require('../lib/__mocks__/walk'));
 
 describe('cms-lib/modules', () => {
   describe('isModuleFolder()', () => {
+    it('should throw on invalid input', () => {
+      expect(() => isModuleFolder('foo')).toThrow();
+      expect(() => isModuleFolder({ path: 'foo' })).toThrow();
+      expect(() => isModuleFolder({ isLocal })).toThrow();
+      expect(() => isModuleFolder({ isHubSpot })).toThrow();
+      expect(() => isModuleFolder({ isHubSpot, path: 'foo' })).not.toThrow();
+      expect(() => isModuleFolder({ isLocal, path: 'foo' })).not.toThrow();
+    });
     it('should return true for module folder paths', () => {
-      moduleFolderPaths.forEach(filepath => {
-        expect(isModuleFolder(filepath)).toBe(true);
-      });
+      let input;
+      // Local
+      input = { isLocal, path: 'My Module.module' };
+      expect(isModuleFolder(input)).toBe(true);
+      input = { isLocal, path: path.join('dir', 'My Module.module') };
+      expect(isModuleFolder(input)).toBe(true);
+      input = { isLocal, path: path.join('dir', 'My Module.module', path.sep) };
+      expect(isModuleFolder(input)).toBe(true);
+      // HubSpot
+      input = { isHubSpot, path: 'My Module.module' };
+      expect(isModuleFolder(input)).toBe(true);
+      input = { isHubSpot, path: 'dir/My Module.module' };
+      expect(isModuleFolder(input)).toBe(true);
+      input = { isHubSpot, path: 'dir/My Module.module/' };
+      expect(isModuleFolder(input)).toBe(true);
     });
     it('should return false for non-module folder paths', () => {
-      folderPaths.forEach(filepath => {
-        expect(isModuleFolder(filepath)).toBe(false);
-      });
+      let input;
+      // Local
+      input = { isLocal, path: 'dir' };
+      expect(isModuleFolder(input)).toBe(false);
+      input = { isLocal, path: path.join('My Module.module', 'dir') };
+      expect(isModuleFolder(input)).toBe(false);
+      // HubSpot
+      input = { isHubSpot, path: 'dir' };
+      expect(isModuleFolder(input)).toBe(false);
+      input = { isHubSpot, path: 'My Module.module/dir' };
+      expect(isModuleFolder(input)).toBe(false);
     });
     it('should return false for file paths', () => {
-      filePaths.forEach(filepath => {
-        expect(isModuleFolder(filepath)).toBe(false);
-      });
+      let input;
+      // Local
+      input = { isLocal, path: 'fields.json' };
+      expect(isModuleFolder(input)).toBe(false);
+      input = { isLocal, path: path.join('My Module.module', 'fields.json') };
+      expect(isModuleFolder(input)).toBe(false);
+      // HubSpot
+      input = { isHubSpot, path: 'fields.json' };
+      expect(isModuleFolder(input)).toBe(false);
+      input = { isHubSpot, path: 'My Module.module/fields.json' };
+      expect(isModuleFolder(input)).toBe(false);
     });
   });
   describe('isModuleFolderChild()', () => {

--- a/packages/cms-lib/__tests__/modules.js
+++ b/packages/cms-lib/__tests__/modules.js
@@ -95,6 +95,8 @@ describe('cms-lib/modules', () => {
       },
       { args: [emptyLocal], ids: [ValidationIds.DEST_REQUIRED] },
       { args: [null, emptyHubSpot], ids: [ValidationIds.SRC_REQUIRED] },
+      { args: [emptyLocal, { isHubSpot }], ids: [ValidationIds.DEST_REQUIRED] },
+      { args: [{ isLocal }, emptyHubSpot], ids: [ValidationIds.SRC_REQUIRED] },
       { args: [emptyLocal, emptyHubSpot], ids: [] },
       { args: [{ isLocal, path: 'x' }, { isHubSpot, path: 'x' }], ids: [] },
     ];

--- a/packages/cms-lib/__tests__/modules.js
+++ b/packages/cms-lib/__tests__/modules.js
@@ -64,11 +64,19 @@ describe('cms-lib/modules', () => {
     it('should return false for non-module folder paths', () => {
       let input;
       // Local
+      input = { isLocal, path: '' };
+      expect(isModuleFolder(input)).toBe(false);
+      input = { isLocal, path: path.sep };
+      expect(isModuleFolder(input)).toBe(false);
       input = { isLocal, path: 'dir' };
       expect(isModuleFolder(input)).toBe(false);
       input = { isLocal, path: path.join('My Module.module', 'dir') };
       expect(isModuleFolder(input)).toBe(false);
       // HubSpot
+      input = { isHubSpot, path: '' };
+      expect(isModuleFolder(input)).toBe(false);
+      input = { isHubSpot, path: '/' };
+      expect(isModuleFolder(input)).toBe(false);
       input = { isHubSpot, path: 'dir' };
       expect(isModuleFolder(input)).toBe(false);
       input = { isHubSpot, path: 'My Module.module/dir' };

--- a/packages/cms-lib/__tests__/modules.js
+++ b/packages/cms-lib/__tests__/modules.js
@@ -26,35 +26,9 @@ const isHubSpot = true;
 const emptyLocal = { isLocal, path: '' };
 const emptyHubSpot = { isHubSpot, path: '' };
 
-jest.mock('../lib/walk', () => {
-  const { join, resolve } = require('path');
-  // Mock file system results in pattern of:
-  //  "*/boilerplate/modules/My Footer.module/fields.json"
-  // So a request for the "boilerplate" dir will work.
-  const testDir = 'boilerplate';
-  const testFiles = [
-    'fields.json',
-    'meta.json',
-    'module.css',
-    'module.html',
-    'module.js',
-  ].map(name => join('modules', 'My Footer.module', name));
-  return {
-    // Given a filepath folder of 'boilerplate/'
-    walk: jest.fn(dir => {
-      const requestDir = resolve(dir);
-      const boilerplateDir = resolve(testDir);
-      if (requestDir !== boilerplateDir) {
-        return Promise.reject(
-          new Error(
-            `ENOENT: no such file or directory, scandir '${requestDir}'`
-          )
-        );
-      }
-      return Promise.resolve(testFiles.map(file => join(boilerplateDir, file)));
-    }),
-  };
-});
+// Seems you can't use nested manual mocks.
+// ca. 2016 https://github.com/facebook/jest/issues/335#issuecomment-250400941
+jest.mock('../lib/walk', () => require('../lib/__mocks__/walk'));
 
 describe('cms-lib/modules', () => {
   describe('isModuleFolder()', () => {

--- a/packages/cms-lib/__tests__/modules.js
+++ b/packages/cms-lib/__tests__/modules.js
@@ -27,27 +27,30 @@ describe('cms-lib/modules', () => {
     it('should return true for module folder paths', () => {
       let input;
       // Local
-      input = { isLocal, path: 'My Module.module' };
+      input = { isLocal, path: 'Card Section.module' };
       expect(isModuleFolder(input)).toBe(true);
-      input = { isLocal, path: path.join('dir', 'My Module.module') };
+      input = { isLocal, path: path.join('dir', 'Card Section.module') };
       expect(isModuleFolder(input)).toBe(true);
       // HubSpot
-      input = { isHubSpot, path: 'My Module.module' };
+      input = { isHubSpot, path: 'Card Section.module' };
       expect(isModuleFolder(input)).toBe(true);
-      input = { isHubSpot, path: 'dir/My Module.module' };
+      input = { isHubSpot, path: 'dir/Card Section.module' };
       expect(isModuleFolder(input)).toBe(true);
     });
     it('should disregard trailing slashes', () => {
       let input;
       // Local
-      input = { isLocal, path: path.join('My Module.module', path.sep) };
+      input = { isLocal, path: path.join('Card Section.module', path.sep) };
       expect(isModuleFolder(input)).toBe(true);
-      input = { isLocal, path: path.join('dir', 'My Module.module', path.sep) };
+      input = {
+        isLocal,
+        path: path.join('dir', 'Card Section.module', path.sep),
+      };
       expect(isModuleFolder(input)).toBe(true);
       // HubSpot
-      input = { isHubSpot, path: 'My Module.module/' };
+      input = { isHubSpot, path: 'Card Section.module/' };
       expect(isModuleFolder(input)).toBe(true);
-      input = { isHubSpot, path: 'dir/My Module.module/' };
+      input = { isHubSpot, path: 'dir/Card Section.module/' };
       expect(isModuleFolder(input)).toBe(true);
     });
     it('should return false for non-module folder paths', () => {
@@ -59,7 +62,7 @@ describe('cms-lib/modules', () => {
       expect(isModuleFolder(input)).toBe(false);
       input = { isLocal, path: 'dir' };
       expect(isModuleFolder(input)).toBe(false);
-      input = { isLocal, path: path.join('My Module.module', 'dir') };
+      input = { isLocal, path: path.join('Card Section.module', 'dir') };
       expect(isModuleFolder(input)).toBe(false);
       // HubSpot
       input = { isHubSpot, path: '' };
@@ -68,7 +71,7 @@ describe('cms-lib/modules', () => {
       expect(isModuleFolder(input)).toBe(false);
       input = { isHubSpot, path: 'dir' };
       expect(isModuleFolder(input)).toBe(false);
-      input = { isHubSpot, path: 'My Module.module/dir' };
+      input = { isHubSpot, path: 'Card Section.module/dir' };
       expect(isModuleFolder(input)).toBe(false);
     });
     it('should return false for file paths', () => {
@@ -76,12 +79,15 @@ describe('cms-lib/modules', () => {
       // Local
       input = { isLocal, path: 'fields.json' };
       expect(isModuleFolder(input)).toBe(false);
-      input = { isLocal, path: path.join('My Module.module', 'fields.json') };
+      input = {
+        isLocal,
+        path: path.join('Card Section.module', 'fields.json'),
+      };
       expect(isModuleFolder(input)).toBe(false);
       // HubSpot
       input = { isHubSpot, path: 'fields.json' };
       expect(isModuleFolder(input)).toBe(false);
-      input = { isHubSpot, path: 'My Module.module/fields.json' };
+      input = { isHubSpot, path: 'Card Section.module/fields.json' };
       expect(isModuleFolder(input)).toBe(false);
     });
   });
@@ -89,34 +95,37 @@ describe('cms-lib/modules', () => {
     it('should return true for child files/folders of module folders', () => {
       let input;
       // Local
-      input = { isLocal, path: path.join('My Module.module', 'dir') };
-      expect(isModuleFolderChild(input)).toBe(true);
-      input = { isLocal, path: path.join('My Module.module', 'fields.json') };
+      input = { isLocal, path: path.join('Card Section.module', 'dir') };
       expect(isModuleFolderChild(input)).toBe(true);
       input = {
         isLocal,
-        path: path.join('dir', 'My Module.module', 'dir', 'fields.json'),
+        path: path.join('Card Section.module', 'fields.json'),
+      };
+      expect(isModuleFolderChild(input)).toBe(true);
+      input = {
+        isLocal,
+        path: path.join('dir', 'Card Section.module', 'dir', 'fields.json'),
       };
       expect(isModuleFolderChild(input)).toBe(true);
       // HubSpot
-      input = { isHubSpot, path: 'My Module.module/dir' };
+      input = { isHubSpot, path: 'Card Section.module/dir' };
       expect(isModuleFolderChild(input)).toBe(true);
-      input = { isHubSpot, path: 'My Module.module/fields.json' };
+      input = { isHubSpot, path: 'Card Section.module/fields.json' };
       expect(isModuleFolderChild(input)).toBe(true);
-      input = { isHubSpot, path: 'dir/My Module.module/dir/fields.json' };
+      input = { isHubSpot, path: 'dir/Card Section.module/dir/fields.json' };
       expect(isModuleFolderChild(input)).toBe(true);
     });
     it('should return false for module folders', () => {
       let input;
       // Local
-      input = { isLocal, path: path.join('dir', 'My Module.module') };
+      input = { isLocal, path: path.join('dir', 'Card Section.module') };
       expect(isModuleFolderChild(input)).toBe(false);
-      input = { isLocal, path: 'My Module.module' };
+      input = { isLocal, path: 'Card Section.module' };
       expect(isModuleFolderChild(input)).toBe(false);
       // HubSpot
-      input = { isHubSpot, path: 'dir/My Module.module' };
+      input = { isHubSpot, path: 'dir/Card Section.module' };
       expect(isModuleFolderChild(input)).toBe(false);
-      input = { isHubSpot, path: 'My Module.module' };
+      input = { isHubSpot, path: 'Card Section.module' };
       expect(isModuleFolderChild(input)).toBe(false);
     });
     it('should return false for folder/file paths not within a module folder', () => {
@@ -175,15 +184,21 @@ describe('cms-lib/modules', () => {
       });
     });
     describe('Guard input conditions', () => {
-      describe('`src` is a module folder as is `dest`', () => {
-        const src = { isLocal, path: 'foo.module' };
-        const dest = { isHubSpot, path: 'modules/foo.module' };
+      describe('VALID: `src` is a module folder as is `dest`', () => {
+        let src = { isLocal, path: 'Card Section.module' };
+        let dest = { isHubSpot, path: 'remote/Card Section.module' };
+        it(`upload ${src.path} ${dest.path}`, async () => {
+          const result = await validateSrcAndDestPaths(src, dest);
+          expect(result.length).toBe(0);
+        });
+        src = { isLocal, path: path.join('dir', '..', 'Card Section.module') };
+        dest = { isHubSpot, path: 'remote/dir/../Card Section.module/' };
         it(`upload ${src.path} ${dest.path}`, async () => {
           const result = await validateSrcAndDestPaths(src, dest);
           expect(result.length).toBe(0);
         });
       });
-      describe('`src` is a module folder but `dest` is not', () => {
+      describe('INVALID: `src` is a module folder but `dest` is not', () => {
         const src = { isLocal, path: 'foo.module' };
         const dest = { isHubSpot, path: 'bar' };
         it(`upload ${src.path} ${dest.path}`, async () => {

--- a/packages/cms-lib/__tests__/modules.js
+++ b/packages/cms-lib/__tests__/modules.js
@@ -42,12 +42,21 @@ describe('cms-lib/modules', () => {
       expect(isModuleFolder(input)).toBe(true);
       input = { isLocal, path: path.join('dir', 'My Module.module') };
       expect(isModuleFolder(input)).toBe(true);
-      input = { isLocal, path: path.join('dir', 'My Module.module', path.sep) };
-      expect(isModuleFolder(input)).toBe(true);
       // HubSpot
       input = { isHubSpot, path: 'My Module.module' };
       expect(isModuleFolder(input)).toBe(true);
       input = { isHubSpot, path: 'dir/My Module.module' };
+      expect(isModuleFolder(input)).toBe(true);
+    });
+    it('should disregard trailing slashes', () => {
+      let input;
+      // Local
+      input = { isLocal, path: path.join('My Module.module', path.sep) };
+      expect(isModuleFolder(input)).toBe(true);
+      input = { isLocal, path: path.join('dir', 'My Module.module', path.sep) };
+      expect(isModuleFolder(input)).toBe(true);
+      // HubSpot
+      input = { isHubSpot, path: 'My Module.module/' };
       expect(isModuleFolder(input)).toBe(true);
       input = { isHubSpot, path: 'dir/My Module.module/' };
       expect(isModuleFolder(input)).toBe(true);

--- a/packages/cms-lib/__tests__/modules.js
+++ b/packages/cms-lib/__tests__/modules.js
@@ -7,19 +7,8 @@ const {
   ValidationIds,
 } = require('../modules');
 
-const folderPaths = ['', '/', 'foo', '/foo'];
-
-const moduleFolderPaths = folderPaths.reduce((acc, folder) => {
-  return acc.concat(
-    path.join(folder, 'widget.module'),
-    path.join(folder, 'my widget.module')
-  );
-}, []);
-
 const isLocal = true;
 const isHubSpot = true;
-const emptyLocal = { isLocal, path: '' };
-const emptyHubSpot = { isHubSpot, path: '' };
 
 // Seems you can't use nested manual mocks.
 // ca. 2016 https://github.com/facebook/jest/issues/335#issuecomment-250400941
@@ -97,45 +86,64 @@ describe('cms-lib/modules', () => {
     });
   });
   describe('isModuleFolderChild()', () => {
-    const createInputs = paths => {
-      return paths.map(p => ({ isHubSpot, path: p }));
-    };
-    const moduleFolderChildrenInputs = moduleFolderPaths.reduce(
-      (acc, folder) => {
-        return acc.concat(
-          { isHubSpot, path: path.join(folder, 'a') },
-          { isHubSpot, path: path.join(folder, 'a/b') },
-          { isHubSpot, path: path.join(folder, 'file.js') },
-          { isHubSpot, path: path.join(folder, 'a/file.js') },
-          { isHubSpot, path: path.join(folder, 'a/b/file.js') }
-        );
-      },
-      []
-    );
     it('should return true for child files/folders of module folders', () => {
-      moduleFolderChildrenInputs.forEach(input => {
-        expect(isModuleFolderChild(input)).toBe(true);
-      });
+      let input;
+      // Local
+      input = { isLocal, path: path.join('My Module.module', 'dir') };
+      expect(isModuleFolderChild(input)).toBe(true);
+      input = { isLocal, path: path.join('My Module.module', 'fields.json') };
+      expect(isModuleFolderChild(input)).toBe(true);
+      input = {
+        isLocal,
+        path: path.join('dir', 'My Module.module', 'dir', 'fields.json'),
+      };
+      expect(isModuleFolderChild(input)).toBe(true);
+      // HubSpot
+      input = { isHubSpot, path: 'My Module.module/dir' };
+      expect(isModuleFolderChild(input)).toBe(true);
+      input = { isHubSpot, path: 'My Module.module/fields.json' };
+      expect(isModuleFolderChild(input)).toBe(true);
+      input = { isHubSpot, path: 'dir/My Module.module/dir/fields.json' };
+      expect(isModuleFolderChild(input)).toBe(true);
     });
     it('should return false for module folders', () => {
-      createInputs(moduleFolderPaths).forEach(filepath => {
-        expect(isModuleFolderChild(filepath)).toBe(false);
-      });
+      let input;
+      // Local
+      input = { isLocal, path: path.join('dir', 'My Module.module') };
+      expect(isModuleFolderChild(input)).toBe(false);
+      input = { isLocal, path: 'My Module.module' };
+      expect(isModuleFolderChild(input)).toBe(false);
+      // HubSpot
+      input = { isHubSpot, path: 'dir/My Module.module' };
+      expect(isModuleFolderChild(input)).toBe(false);
+      input = { isHubSpot, path: 'My Module.module' };
+      expect(isModuleFolderChild(input)).toBe(false);
     });
-    it('should return false for folder paths not within a module folder', () => {
-      createInputs(folderPaths).forEach(filepath => {
-        expect(isModuleFolderChild(filepath)).toBe(false);
-      });
-    });
-    it('should return false for file paths not within a module folder', () => {
-      createInputs(
-        folderPaths.map(folder => path.join(folder, 'file.js'))
-      ).forEach(filepath => {
-        expect(isModuleFolderChild(filepath)).toBe(false);
-      });
+    it('should return false for folder/file paths not within a module folder', () => {
+      let input;
+      // Local
+      input = { isLocal, path: path.join('dir', 'dir') };
+      expect(isModuleFolderChild(input)).toBe(false);
+      input = { isLocal, path: path.join('dir', 'fields.json') };
+      expect(isModuleFolderChild(input)).toBe(false);
+      input = { isLocal, path: 'dir' };
+      expect(isModuleFolderChild(input)).toBe(false);
+      input = { isLocal, path: 'fields.json' };
+      expect(isModuleFolderChild(input)).toBe(false);
+      // HubSpot
+      input = { isHubSpot, path: 'dir/dir' };
+      expect(isModuleFolderChild(input)).toBe(false);
+      input = { isHubSpot, path: 'dir/fields.json' };
+      expect(isModuleFolderChild(input)).toBe(false);
+      input = { isHubSpot, path: 'dir' };
+      expect(isModuleFolderChild(input)).toBe(false);
+      input = { isHubSpot, path: 'fields.json' };
+      expect(isModuleFolderChild(input)).toBe(false);
     });
   });
   describe('validateSrcAndDestPaths()', () => {
+    const emptyLocal = { isLocal, path: '' };
+    const emptyHubSpot = { isHubSpot, path: '' };
     const simpleTestCases = [
       {
         args: [],

--- a/packages/cms-lib/__tests__/modules.js
+++ b/packages/cms-lib/__tests__/modules.js
@@ -7,6 +7,8 @@ const {
   ValidationIds,
 } = require('../modules');
 
+const walk = require('../lib/walk');
+
 const isLocal = true;
 const isHubSpot = true;
 
@@ -204,6 +206,13 @@ describe('cms-lib/modules', () => {
       result = await validateSrcAndDestPaths(src, dest);
       expect(result.length).toBe(0);
     });
+    it('should walk local files if needed', async () => {
+      const src = { isLocal, path: 'boilerplate' };
+      const dest = { isHubSpot, path: 'Card Section.module/js' };
+      const spy = jest.spyOn(walk, 'walk');
+      await validateSrcAndDestPaths(src, dest);
+      expect(spy).toHaveBeenCalled();
+    });
     describe('hs upload', () => {
       describe('VALID: `src` is a module folder as is `dest`', () => {
         let src = { isLocal, path: 'Card Section.module' };
@@ -232,7 +241,6 @@ describe('cms-lib/modules', () => {
             ValidationIds.MODULE_FOLDER_REQUIRED
           );
         });
-        // src = { isLocal, path: 'Card Section.module' };
         src = {
           isLocal,
           path: path.join('boilerplate', 'modules', 'Card Section.module'),
@@ -247,13 +255,7 @@ describe('cms-lib/modules', () => {
         });
         src = {
           isLocal,
-          path: path.join(
-            'boilerplate',
-            'modules',
-            'Card Section.module',
-            'js',
-            '..'
-          ),
+          path: path.join('boilerplate', 'modules', 'Card Section.module'),
         };
         dest = { isHubSpot, path: 'remote/boilerplate/modules/' };
         it(`upload "${src.path}" "${dest.path}"`, async () => {
@@ -264,9 +266,9 @@ describe('cms-lib/modules', () => {
           );
         });
       });
-      describe('`src` is a .module folder and dest is within a module. (Nesting)', () => {
-        const src = { isLocal, path: 'foo.module' };
-        const dest = { isHubSpot, path: 'bar.module/zzz' };
+      describe('INVALID: `src` is a .module folder and `dest` is within a module. (Nesting)', () => {
+        const src = { isLocal, path: 'Car Section.module' };
+        const dest = { isHubSpot, path: 'Car Section.module/js' };
         it(`upload "${src.path}" "${dest.path}"`, async () => {
           const result = await validateSrcAndDestPaths(src, dest);
           expect(result.length).toBe(1);
@@ -275,9 +277,9 @@ describe('cms-lib/modules', () => {
           );
         });
       });
-      describe('src is a folder that includes modules and dest is within a module. (Nesting)', () => {
+      describe('INVALID: `src` is a folder that includes modules and `dest` is within a module. (Nesting)', () => {
         const src = { isLocal, path: 'boilerplate' };
-        const dest = { isHubSpot, path: 'bar.module/zzz' };
+        const dest = { isHubSpot, path: 'Card Section.module/js' };
         it(`upload "${src.path}" "${dest.path}"`, async () => {
           const result = await validateSrcAndDestPaths(src, dest);
           expect(result.length).toBe(1);

--- a/packages/cms-lib/__tests__/modules.js
+++ b/packages/cms-lib/__tests__/modules.js
@@ -184,24 +184,23 @@ describe('cms-lib/modules', () => {
       });
     });
     it('should normalize paths', async () => {
-      const modName = 'Car Section.module';
-      let src = { isLocal, path: modName };
-      let dest = { isHubSpot, path: `${modName}/js/../` };
+      let src = { isLocal, path: 'Car Section.module' };
+      let dest = { isHubSpot, path: 'Car Section.module/js/../' };
       let result = await validateSrcAndDestPaths(src, dest);
       expect(result.length).toBe(0);
-      src = { isLocal, path: path.join(modName, 'js', '..') };
-      dest = { isHubSpot, path: modName };
+      src = { isLocal, path: path.join('Car Section.module', 'js', '..') };
+      dest = { isHubSpot, path: 'Car Section.module' };
       result = await validateSrcAndDestPaths(src, dest);
       expect(result.length).toBe(0);
-      src = { isLocal, path: modName };
-      dest = { isHubSpot, path: `${modName}/js/main.js/../` };
+      src = { isLocal, path: 'Car Section.module' };
+      dest = { isHubSpot, path: 'Car Section.module/js/main.js/../' };
       result = await validateSrcAndDestPaths(src, dest);
       expect(result.length).toBe(1);
       src = {
         isLocal,
-        path: path.join(modName, 'js', 'main.js', '..', path.sep),
+        path: path.join('Car Section.module', 'js', 'main.js', '..', path.sep),
       };
-      dest = { isHubSpot, path: modName };
+      dest = { isHubSpot, path: 'Car Section.module' };
       result = await validateSrcAndDestPaths(src, dest);
       expect(result.length).toBe(0);
     });

--- a/packages/cms-lib/__tests__/path.js
+++ b/packages/cms-lib/__tests__/path.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { splitHubSpotPath } = require('../path');
+const { splitHubSpotPath, splitLocalPath } = require('../path');
 
 describe('cms-lib/path', () => {
   describe('splitHubSpotPath()', () => {
@@ -10,6 +10,7 @@ describe('cms-lib/path', () => {
         expect(path.posix.join(...parts)).toBe(joined);
       });
     };
+    testSplit('', [], '.');
     testSplit('a', ['a'], 'a');
     testSplit('a/b', ['a', 'b'], 'a/b');
     testSplit('a/b/', ['a', 'b'], 'a/b');
@@ -24,11 +25,6 @@ describe('cms-lib/path', () => {
     testSplit('/x/a.js/', ['/', 'x', 'a.js'], '/x/a.js');
     testSplit('///x/////a.js///', ['/', 'x', 'a.js'], '/x/a.js');
     testSplit(
-      'project/My Module.module',
-      ['project', 'My Module.module'],
-      'project/My Module.module'
-    );
-    testSplit(
       '/project/My Module.module',
       ['/', 'project', 'My Module.module'],
       '/project/My Module.module'
@@ -38,11 +34,86 @@ describe('cms-lib/path', () => {
       ['project', 'My Module.module', 'js'],
       'project/My Module.module/js'
     );
-
     testSplit(
       'project/My Module.module/js/main.js/',
       ['project', 'My Module.module', 'js', 'main.js'],
       'project/My Module.module/js/main.js'
     );
+    testSplit(
+      'project/My Module.module/js/../css/',
+      ['project', 'My Module.module', 'css'],
+      'project/My Module.module/css'
+    );
+    testSplit(
+      './project/My Module.module/js',
+      ['project', 'My Module.module', 'js'],
+      'project/My Module.module/js'
+    );
+    testSplit(
+      '../project/My Module.module/js',
+      ['..', 'project', 'My Module.module', 'js'],
+      '../project/My Module.module/js'
+    );
+  });
+  describe('splitLocalPath()', () => {
+    const createTestSplit = pathImplementation => {
+      return (filepath, expectedParts, joined) => {
+        test(filepath, () => {
+          const parts = splitLocalPath(filepath, pathImplementation);
+          expect(parts).toEqual(expectedParts);
+          expect(pathImplementation.join(...parts)).toBe(joined);
+        });
+      };
+    };
+    const getLocalFileSystemTestCases = pathImplementation => {
+      const { sep } = pathImplementation;
+      const isWin32 = sep === path.win32.sep;
+      const splitRoot = isWin32 ? 'C:' : '/';
+      const pathRoot = isWin32 ? 'C:\\' : '/';
+      return [
+        [
+          `${pathRoot}My Module.module`,
+          [splitRoot, 'My Module.module'],
+          `${pathRoot}My Module.module`,
+        ],
+        [
+          `${pathRoot}My Module.module${sep}`,
+          [splitRoot, 'My Module.module'],
+          `${pathRoot}My Module.module`,
+        ],
+        [`My Module.module${sep}`, ['My Module.module'], 'My Module.module'],
+        [
+          `${pathRoot}My Module.module${sep}js${sep}main.js`,
+          [splitRoot, 'My Module.module', 'js', 'main.js'],
+          `${pathRoot}My Module.module${sep}js${sep}main.js`,
+        ],
+        [
+          `${pathRoot}My Module.module${sep}${sep}${sep}js${sep}main.js${sep}${sep}`,
+          [splitRoot, 'My Module.module', 'js', 'main.js'],
+          `${pathRoot}My Module.module${sep}js${sep}main.js`,
+        ],
+        [
+          `${pathRoot}My Module.module${sep}js${sep}..${sep}css`,
+          [splitRoot, 'My Module.module', 'css'],
+          `${pathRoot}My Module.module${sep}css`,
+        ],
+        [
+          `My Module.module${sep}js${sep}..${sep}css`,
+          ['My Module.module', 'css'],
+          `My Module.module${sep}css`,
+        ],
+      ];
+    };
+    ['posix', 'win32'].forEach(platform => {
+      describe(platform, () => {
+        const pathImplementation = path[platform];
+        const testSplit = createTestSplit(pathImplementation);
+        const testCases = getLocalFileSystemTestCases(pathImplementation);
+        if (!(testCases && testCases.length)) {
+          throw new Error(`Missing ${platform} splitLocalPath() test cases`);
+        }
+        testCases.forEach(testCase => testSplit(...testCase));
+      });
+    });
   });
 });

--- a/packages/cms-lib/__tests__/path.js
+++ b/packages/cms-lib/__tests__/path.js
@@ -1,0 +1,48 @@
+const path = require('path');
+const { splitHubSpotPath } = require('../path');
+
+describe('cms-lib/path', () => {
+  describe('splitHubSpotPath()', () => {
+    const testSplit = (filepath, expectedParts, joined) => {
+      test(filepath, () => {
+        const parts = splitHubSpotPath(filepath);
+        expect(parts).toEqual(expectedParts);
+        expect(path.posix.join(...parts)).toBe(joined);
+      });
+    };
+    testSplit('a', ['a'], 'a');
+    testSplit('a/b', ['a', 'b'], 'a/b');
+    testSplit('a/b/', ['a', 'b'], 'a/b');
+    testSplit('a/b///', ['a', 'b'], 'a/b');
+    testSplit('/', ['/'], '/');
+    testSplit('///', ['/'], '/');
+    testSplit('/a', ['/', 'a'], '/a');
+    testSplit('///a', ['/', 'a'], '/a');
+    testSplit('/a/b', ['/', 'a', 'b'], '/a/b');
+    testSplit('a.js', ['a.js'], 'a.js');
+    testSplit('/a.js/', ['/', 'a.js'], '/a.js');
+    testSplit('/x/a.js/', ['/', 'x', 'a.js'], '/x/a.js');
+    testSplit('///x/////a.js///', ['/', 'x', 'a.js'], '/x/a.js');
+    testSplit(
+      'project/My Module.module',
+      ['project', 'My Module.module'],
+      'project/My Module.module'
+    );
+    testSplit(
+      '/project/My Module.module',
+      ['/', 'project', 'My Module.module'],
+      '/project/My Module.module'
+    );
+    testSplit(
+      'project/My Module.module/js',
+      ['project', 'My Module.module', 'js'],
+      'project/My Module.module/js'
+    );
+
+    testSplit(
+      'project/My Module.module/js/main.js/',
+      ['project', 'My Module.module', 'js', 'main.js'],
+      'project/My Module.module/js/main.js'
+    );
+  });
+});

--- a/packages/cms-lib/lib/__mocks__/walk.js
+++ b/packages/cms-lib/lib/__mocks__/walk.js
@@ -18,7 +18,7 @@ const testFiles = [
   'module.js',
 ].map(name => path.join('modules', 'Card Section.module', name));
 
-walk.walk = dir => {
+walk.walk = jest.fn(dir => {
   const requestDir = path.resolve(dir);
   const boilerplateDir = path.resolve(testDir);
   if (requestDir !== boilerplateDir) {
@@ -29,6 +29,6 @@ walk.walk = dir => {
   return Promise.resolve(
     testFiles.map(file => path.join(boilerplateDir, file))
   );
-};
+});
 
 module.exports = walk;

--- a/packages/cms-lib/lib/__mocks__/walk.js
+++ b/packages/cms-lib/lib/__mocks__/walk.js
@@ -1,0 +1,34 @@
+const path = require('path');
+
+const walk = jest.genMockFromModule('../walk');
+
+/*
+ * File results mocked in pattern of:
+ *  "<resolved>/boilerplate/modules/My Footer.module/fields.json"
+ * A request for the "boilerplate" dir will work.
+ * Other requests will error.
+ */
+
+const testDir = 'boilerplate';
+const testFiles = [
+  'fields.json',
+  'meta.json',
+  'module.css',
+  'module.html',
+  'module.js',
+].map(name => path.join('modules', 'My Footer.module', name));
+
+walk.walk = dir => {
+  const requestDir = path.resolve(dir);
+  const boilerplateDir = path.resolve(testDir);
+  if (requestDir !== boilerplateDir) {
+    return Promise.reject(
+      new Error(`ENOENT: no such file or directory, scandir '${requestDir}'`)
+    );
+  }
+  return Promise.resolve(
+    testFiles.map(file => path.join(boilerplateDir, file))
+  );
+};
+
+module.exports = walk;

--- a/packages/cms-lib/lib/__mocks__/walk.js
+++ b/packages/cms-lib/lib/__mocks__/walk.js
@@ -16,7 +16,7 @@ const testFiles = [
   'module.css',
   'module.html',
   'module.js',
-].map(name => path.join('modules', 'My Footer.module', name));
+].map(name => path.join('modules', 'Card Section.module', name));
 
 walk.walk = dir => {
   const requestDir = path.resolve(dir);

--- a/packages/cms-lib/modules.js
+++ b/packages/cms-lib/modules.js
@@ -106,7 +106,6 @@ async function validateSrcAndDestPaths(src, dest) {
   });
   // src is a .module folder and dest is within a module. (Nesting)
   // e.g. `upload foo.module bar.module/zzz`
-  // e.g. `fetch bar.module/zzz foo.module`
   if (isModuleFolder(_src) && isModuleFolderChild(_dest)) {
     return results.concat(
       getValidationResult(
@@ -117,7 +116,6 @@ async function validateSrcAndDestPaths(src, dest) {
   }
   // src is a .module folder but dest is not
   // e.g. `upload foo.module bar`
-  // e.g. `fetch bar foo.module`
   if (isModuleFolder(_src) && !isModuleFolder(_dest)) {
     return results.concat(
       getValidationResult(

--- a/packages/cms-lib/modules.js
+++ b/packages/cms-lib/modules.js
@@ -142,6 +142,7 @@ async function validateSrcAndDestPaths(src, dest) {
       }
     }
   }
+  // TODO: Add local FS check for dest.isLocal to support `fetch`
   return results;
 }
 

--- a/packages/cms-lib/modules.js
+++ b/packages/cms-lib/modules.js
@@ -4,11 +4,22 @@ const { getCwd, getExt } = require('./path');
 const { walk } = require('./lib/walk');
 const { MODULE_EXTENSION } = require('./lib/constants');
 
+const splitPath = filepath => {
+  if (typeof filepath !== 'string') return [];
+  filepath = filepath.trim();
+  if (!filepath) return [];
+  const splitRegex = new RegExp(`${path.posix.sep}+|${path.win32.sep}+`);
+  return filepath.split(splitRegex).filter(Boolean);
+};
+
 const isModuleFolder = filepath => getExt(filepath) === MODULE_EXTENSION;
 const isModuleFolderChild = filepath => {
-  if (typeof filepath !== 'string') return false;
-  if (isModuleFolder(filepath)) return true;
-  return filepath.split(/\/|\\/).some(folder => isModuleFolder(folder));
+  const pathParts = splitPath(filepath);
+  const { length } = pathParts;
+  // Not a child path?
+  if (length <= 1) return false;
+  // Check if any parent folders are module folders.
+  return pathParts.slice(0, length - 1).some(isModuleFolder);
 };
 
 // Ids for testing
@@ -78,6 +89,8 @@ async function validateSrcAndDestPaths(src, dest) {
 }
 
 module.exports = {
+  isModuleFolder,
+  isModuleFolderChild,
   validateSrcAndDestPaths,
   ValidationIds,
 };

--- a/packages/cms-lib/modules.js
+++ b/packages/cms-lib/modules.js
@@ -31,11 +31,14 @@ const throwInvalidPathInput = pathInput => {
 };
 
 /**
- * @param {PathInput|string} pathInput
+ * @param {PathInput} pathInput
  * @returns {boolean}
  */
 const isModuleFolder = pathInput => {
-  const _path = isPathInput(pathInput) ? pathInput.path : pathInput;
+  throwInvalidPathInput(pathInput);
+  const _path = pathInput.isHubSpot
+    ? path.posix.normalize(pathInput.path)
+    : path.normalize(pathInput.path);
   return getExt(_path) === MODULE_EXTENSION;
 };
 
@@ -56,7 +59,9 @@ const isModuleFolderChild = pathInput => {
   // Not a child path?
   if (length <= 1) return false;
   // Check if any parent folders are module folders.
-  return pathParts.slice(0, length - 1).some(isModuleFolder);
+  return pathParts
+    .slice(0, length - 1)
+    .some(part => isModuleFolder({ ...pathInput, path: part }));
 };
 
 // Ids for testing
@@ -94,6 +99,8 @@ async function validateSrcAndDestPaths(src, dest) {
     const result = { ...inputPath };
     if (result.isLocal) {
       result.path = path.resolve(getCwd(), result.path);
+    } else if (result.isHubSpot) {
+      result.path = path.posix.normalize(result.path);
     }
     return result;
   });

--- a/packages/cms-lib/path.js
+++ b/packages/cms-lib/path.js
@@ -33,7 +33,7 @@ const removeTrailingSlashFromSplits = parts => {
 };
 
 /**
- * Splits a filepath for the local file system sources.
+ * Splits a filepath for local file system sources.
  *
  * @param {string} filepath
  * @param {object} pathImplementation - For testing
@@ -43,7 +43,6 @@ const splitLocalPath = (filepath, pathImplementation = path) => {
   if (!filepath) return [];
   const { sep } = pathImplementation;
   const rgx = new RegExp(`\\${sep}+`, 'g');
-  filepath = filepath.replace(rgx, sep);
   const parts = pathImplementation.normalize(filepath).split(rgx);
   // Restore posix root if present
   if (sep === path.posix.sep && parts[0] === '') {
@@ -62,7 +61,6 @@ const splitHubSpotPath = filepath => {
   if (!filepath) return [];
   const sep = path.posix.sep;
   const rgx = new RegExp(`\\${sep}+`, 'g');
-  filepath = filepath.replace(rgx, sep);
   const parts = convertToUnixPath(filepath).split(rgx);
   // Restore root if present
   if (parts[0] === '') {

--- a/packages/cms-lib/path.js
+++ b/packages/cms-lib/path.js
@@ -41,10 +41,14 @@ const removeTrailingSlashFromSplits = parts => {
  */
 const splitLocalPath = (filepath, pathImplementation = path) => {
   if (!filepath) return [];
-  const sep = pathImplementation.sep;
+  const { sep } = pathImplementation;
   const rgx = new RegExp(`\\${sep}+`, 'g');
   filepath = filepath.replace(rgx, sep);
   const parts = pathImplementation.normalize(filepath).split(rgx);
+  // Restore posix root if present
+  if (sep === path.posix.sep && parts[0] === '') {
+    parts[0] = '/';
+  }
   return removeTrailingSlashFromSplits(parts);
 };
 

--- a/packages/cms-lib/path.js
+++ b/packages/cms-lib/path.js
@@ -59,8 +59,7 @@ const splitLocalPath = (filepath, pathImplementation = path) => {
  */
 const splitHubSpotPath = filepath => {
   if (!filepath) return [];
-  const sep = path.posix.sep;
-  const rgx = new RegExp(`\\${sep}+`, 'g');
+  const rgx = new RegExp(`\\${path.posix.sep}+`, 'g');
   const parts = convertToUnixPath(filepath).split(rgx);
   // Restore root if present
   if (parts[0] === '') {

--- a/packages/cms-lib/path.js
+++ b/packages/cms-lib/path.js
@@ -21,6 +21,26 @@ const convertToLocalFileSystemPath = _path => {
   }
 };
 
+/**
+ * Splits a filepath for the local file system sources.
+ *
+ * @param {string} filepath
+ * @returns {string[]}
+ */
+const splitLocalPath = filepath => {
+  return path.normalize(filepath).split(path.sep);
+};
+
+/**
+ * Splits a filepath for remote sources (HubSpot).
+ *
+ * @param {string} filepath
+ * @returns {string[]}
+ */
+const splitHubSpotPath = filepath => {
+  return convertToUnixPath(filepath).split(path.posix.sep);
+};
+
 const getCwd = () => {
   if (process.env.INIT_CWD) {
     return process.env.INIT_CWD;
@@ -55,4 +75,6 @@ module.exports = {
   getCwd,
   getExt,
   isAllowedExtension,
+  splitLocalPath,
+  splitHubSpotPath,
 };

--- a/packages/cms-lib/path.js
+++ b/packages/cms-lib/path.js
@@ -23,13 +23,29 @@ const convertToLocalFileSystemPath = _path => {
 };
 
 /**
+ * @param {string[]} parts
+ */
+const removeTrailingSlashFromSplits = parts => {
+  if (parts.length > 1 && parts[parts.length - 1] === '') {
+    return parts.slice(0, parts.length - 1);
+  }
+  return parts;
+};
+
+/**
  * Splits a filepath for the local file system sources.
  *
  * @param {string} filepath
+ * @param {object} pathImplementation - For testing
  * @returns {string[]}
  */
-const splitLocalPath = filepath => {
-  return path.normalize(filepath).split(path.sep);
+const splitLocalPath = (filepath, pathImplementation = path) => {
+  if (!filepath) return [];
+  const sep = pathImplementation.sep;
+  const rgx = new RegExp(`\\${sep}+`, 'g');
+  filepath = filepath.replace(rgx, sep);
+  const parts = pathImplementation.normalize(filepath).split(rgx);
+  return removeTrailingSlashFromSplits(parts);
 };
 
 /**
@@ -39,7 +55,16 @@ const splitLocalPath = filepath => {
  * @returns {string[]}
  */
 const splitHubSpotPath = filepath => {
-  return convertToUnixPath(filepath).split(path.posix.sep);
+  if (!filepath) return [];
+  const sep = path.posix.sep;
+  const rgx = new RegExp(`\\${sep}+`, 'g');
+  filepath = filepath.replace(rgx, sep);
+  const parts = convertToUnixPath(filepath).split(rgx);
+  // Restore root if present
+  if (parts[0] === '') {
+    parts[0] = '/';
+  }
+  return removeTrailingSlashFromSplits(parts);
 };
 
 const getCwd = () => {

--- a/packages/cms-lib/path.js
+++ b/packages/cms-lib/path.js
@@ -7,14 +7,15 @@ const convertToUnixPath = _path => {
 };
 
 const convertToWindowsPath = _path => {
-  return path.normalize(_path).replace(/\//g, '\\');
+  const rgx = new RegExp(`\\${path.posix.sep}`, 'g');
+  return path.normalize(_path).replace(rgx, path.win32.sep);
 };
 
 const convertToLocalFileSystemPath = _path => {
   switch (path.sep) {
-    case '/':
+    case path.posix.sep:
       return convertToUnixPath(_path);
-    case '\\':
+    case path.win32.sep:
       return convertToWindowsPath(_path);
     default:
       return path.normalize(_path);
@@ -75,6 +76,6 @@ module.exports = {
   getCwd,
   getExt,
   isAllowedExtension,
-  splitLocalPath,
   splitHubSpotPath,
+  splitLocalPath,
 };


### PR DESCRIPTION
Fixes module `src/dest` validation where uploading from a module path to a module path was returning invalid.

```shell
$ hs upload /local/widget.module /remote/widget.module
```

- Examines both local, filesystem dependent paths and HubSpot, posix paths.  Added methods and test for both.
- Updated tests so that they run in both win and *nix environments.
- Fixed issues where paths not normalized were incorrectly causing a pass or fail.
- Fixed issues where trailing slashes were incorrectly causing a pass or fail.
- Made tests more readable, and mock data more representative of HubSpot style projects.