### PR TITLE
Add create and fetch commands for managing HubDB tables

### DIFF
--- a/packages/cms-cli/bin/hs-hubdb-create.js
+++ b/packages/cms-cli/bin/hs-hubdb-create.js
@@ -1,0 +1,9 @@
+#!/usr/bin/en node
+
+const { Command } = require('commander');
+
+const { configureHubDbCreateCommand } = require('../commands/hubdb');
+
+const program = new Command('hs hubdb create');
+configureHubDbCreateCommand(program);
+program.parse(process.argv);

--- a/packages/cms-cli/bin/hs-hubdb-fetch.js
+++ b/packages/cms-cli/bin/hs-hubdb-fetch.js
@@ -1,0 +1,9 @@
+#!/usr/bin/en node
+
+const { Command } = require('commander');
+
+const { configureHubDbFetchCommand } = require('../commands/hubdb');
+
+const program = new Command('hs hubdb fetch');
+configureHubDbFetchCommand(program);
+program.parse(process.argv);

--- a/packages/cms-cli/bin/hs-hubdb.js
+++ b/packages/cms-cli/bin/hs-hubdb.js
@@ -1,0 +1,9 @@
+#!/usr/bin/en node
+
+const { Command } = require('commander');
+
+const { configureHubDbCommand } = require('../commands/hubdb');
+
+const program = new Command('hs hubdb');
+configureHubDbCommand(program);
+program.parse(process.argv);

--- a/packages/cms-cli/bin/hscms-hubdb-create.js
+++ b/packages/cms-cli/bin/hscms-hubdb-create.js
@@ -1,0 +1,9 @@
+#!/usr/bin/en node
+
+const { Command } = require('commander');
+
+const { configureHubDbCreateCommand } = require('../commands/hubdb');
+
+const program = new Command('hscms hubdb create');
+configureHubDbCreateCommand(program);
+program.parse(process.argv);

--- a/packages/cms-cli/bin/hscms-hubdb-fetch.js
+++ b/packages/cms-cli/bin/hscms-hubdb-fetch.js
@@ -1,0 +1,9 @@
+#!/usr/bin/en node
+
+const { Command } = require('commander');
+
+const { configureHubDbFetchCommand } = require('../commands/hubdb');
+
+const program = new Command('hscms hubdb fetch');
+configureHubDbFetchCommand(program);
+program.parse(process.argv);

--- a/packages/cms-cli/bin/hscms-hubdb.js
+++ b/packages/cms-cli/bin/hscms-hubdb.js
@@ -1,0 +1,9 @@
+#!/usr/bin/en node
+
+const { Command } = require('commander');
+
+const { configureHubDbCommand } = require('../commands/hubdb');
+
+const program = new Command('hs hubdb');
+configureHubDbCommand(program);
+program.parse(process.argv);

--- a/packages/cms-cli/commands/hubdb.js
+++ b/packages/cms-cli/commands/hubdb.js
@@ -3,7 +3,10 @@ const path = require('path');
 const { loadConfig } = require('@hubspot/cms-lib');
 const { logger } = require('@hubspot/cms-lib/logger');
 const { getCwd } = require('@hubspot/cms-lib/path');
-const { createHubDbTable } = require('@hubspot/cms-lib/hubdb');
+const {
+  createHubDbTable,
+  downloadHubDbTable,
+} = require('@hubspot/cms-lib/hubdb');
 
 const { validateConfig, validatePortal } = require('../lib/validation');
 const { addHelpUsageTracking } = require('../lib/usageTracking');
@@ -18,16 +21,15 @@ const {
 } = require('../lib/commonOpts');
 const { logDebugInfo } = require('../lib/debugInfo');
 
-
 function configureHubDbCommand(program) {
   program
     .version(version)
     .description('Manage HubDB tables')
     .command('create <src>', 'create a HubDB table')
+    .command('fetch <tableId> <dest>', 'fetch a HubDB table');
 
   addLoggerOptions(program);
   addHelpUsageTracking(program);
-
 }
 
 function configureHubDbCreateCommand(program) {
@@ -65,7 +67,40 @@ function configureHubDbCreateCommand(program) {
   addConfigOptions(program);
 }
 
+function configureHubDbFetchCommand(program) {
+  program
+    .version(version)
+    .description('Fetch a HubDB table')
+    .arguments('<tableId> <dest>')
+    .action(async (tableId, dest, command = {}) => {
+      setLogLevel(command);
+      logDebugInfo(command);
+      const { config: configPath } = command;
+      loadConfig(configPath);
+
+      if (!(validateConfig() && (await validatePortal(command)))) {
+        process.exit(1);
+      }
+      const portalId = getPortalId(command);
+      try {
+        await downloadHubDbTable(
+          portalId,
+          tableId,
+          path.resolve(getCwd(), dest)
+        );
+        logger.log(`Downloaded HubDB table ${tableId} to ${dest}`);
+      } catch (e) {
+        logger.error(e);
+      }
+    });
+
+  addLoggerOptions(program);
+  addPortalOptions(program);
+  addConfigOptions(program);
+}
+
 module.exports = {
   configureHubDbCommand,
   configureHubDbCreateCommand,
+  configureHubDbFetchCommand,
 };

--- a/packages/cms-cli/commands/hubdb.js
+++ b/packages/cms-cli/commands/hubdb.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+const path = require('path');
+const { loadConfig } = require('@hubspot/cms-lib');
+const { logger } = require('@hubspot/cms-lib/logger');
+const { getCwd } = require('@hubspot/cms-lib/path');
+const { createHubDbTable } = require('@hubspot/cms-lib/hubdb');
+
+const { validateConfig, validatePortal } = require('../lib/validation');
+const { version } = require('../package.json');
+
+const {
+  addConfigOptions,
+  addLoggerOptions,
+  addPortalOptions,
+  setLogLevel,
+  getPortalId,
+} = require('../lib/commonOpts');
+const { logDebugInfo } = require('../lib/debugInfo');
+
+function configureHubDbCommand(program, bin) {
+  program
+    .version(version)
+    .description('Manage HubDB tables')
+    .arguments('<subcommand> <src>')
+    .action(async (subcommand, src, command = {}) => {
+      setLogLevel(command);
+      logDebugInfo(command);
+      const { config: configPath } = command;
+      loadConfig(configPath);
+
+      if (!(validateConfig() && (await validatePortal(command)))) {
+        process.exit(1);
+      }
+      const portalId = getPortalId(command);
+
+      switch (subcommand) {
+        case 'create':
+          try {
+            const table = await createHubDbTable(
+              portalId,
+              path.resolve(getCwd(), src)
+            );
+            logger.log(
+              `The table ${table.tableId} was created in ${portalId} with ${table.rowCount} rows`
+            );
+          } catch (e) {
+            logger.error(`Creating the table at "${src}" failed`);
+            logger.error(e.message);
+          }
+          break;
+        default:
+          logger.error(`The command "${bin} hubdb ${subcommand}" is not valid`);
+      }
+    });
+
+  addLoggerOptions(program);
+  addPortalOptions(program);
+  addConfigOptions(program);
+}
+
+module.exports = {
+  configureHubDbCommand,
+};

--- a/packages/cms-cli/commands/main.js
+++ b/packages/cms-cli/commands/main.js
@@ -18,6 +18,7 @@ function configureMainCommand(program) {
     .command('lint <path>', 'lint a file or folder for HubL syntax', {
       noHelp: true,
     })
+    .command('hubdb <subcommand> <src>', 'manage hubdb tables')
     .command('remove <path>', 'delete a file or folder from HubSpot')
     .alias('rm');
 

--- a/packages/cms-cli/commands/main.js
+++ b/packages/cms-cli/commands/main.js
@@ -18,7 +18,9 @@ function configureMainCommand(program) {
     .command('lint <path>', 'lint a file or folder for HubL syntax', {
       noHelp: true,
     })
-    .command('hubdb <subcommand> <src>', 'manage hubdb tables')
+    .command('hubdb <subcommand> <src>', 'manage hubdb tables', {
+      noHelp: true,
+    })
     .command('remove <path>', 'delete a file or folder from HubSpot')
     .alias('rm');
 

--- a/packages/cms-lib/api/hubdb.js
+++ b/packages/cms-lib/api/hubdb.js
@@ -14,6 +14,12 @@ async function createTable(portalId, schema) {
   });
 }
 
+async function publishTable(portalId, tableId) {
+  return http.put(portalId, {
+    uri: `${HUBDB_API_PATH}/tables/${tableId}/publish`,
+  });
+}
+
 async function updateRows(portalId, tableId, rows) {
   return http.post(portalId, {
     uri: `${HUBDB_API_PATH}/tables/${tableId}/rows/batch/update`,
@@ -35,9 +41,10 @@ async function fetchRows(portalId, tableId) {
 }
 
 module.exports = {
-  createTable,
-  updateRows,
   createRows,
-  fetchTables,
+  createTable,
   fetchRows,
+  fetchTables,
+  publishTable,
+  updateRows,
 };

--- a/packages/cms-lib/api/hubdb.js
+++ b/packages/cms-lib/api/hubdb.js
@@ -7,6 +7,12 @@ async function fetchTables(portalId) {
   });
 }
 
+async function fetchTable(portalId, tableId) {
+  return http.get(portalId, {
+    uri: `${HUBDB_API_PATH}/tables/${tableId}`,
+  });
+}
+
 async function createTable(portalId, schema) {
   return http.post(portalId, {
     uri: `${HUBDB_API_PATH}/tables`,
@@ -34,9 +40,10 @@ async function createRows(portalId, tableId, rows) {
   });
 }
 
-async function fetchRows(portalId, tableId) {
+async function fetchRows(portalId, tableId, query = {}) {
   return http.get(portalId, {
     uri: `${HUBDB_API_PATH}/tables/${tableId}/rows`,
+    query,
   });
 }
 
@@ -44,6 +51,7 @@ module.exports = {
   createRows,
   createTable,
   fetchRows,
+  fetchTable,
   fetchTables,
   publishTable,
   updateRows,

--- a/packages/cms-lib/api/hubdb.js
+++ b/packages/cms-lib/api/hubdb.js
@@ -7,6 +7,27 @@ async function fetchTables(portalId) {
   });
 }
 
+async function createTable(portalId, schema) {
+  return http.post(portalId, {
+    uri: `${HUBDB_API_PATH}/tables`,
+    body: schema,
+  });
+}
+
+async function updateRows(portalId, tableId, rows) {
+  return http.post(portalId, {
+    uri: `${HUBDB_API_PATH}/tables/${tableId}/rows/batch/update`,
+    body: rows,
+  });
+}
+
+async function createRows(portalId, tableId, rows) {
+  return http.post(portalId, {
+    uri: `${HUBDB_API_PATH}/tables/${tableId}/rows/batch/create`,
+    body: rows,
+  });
+}
+
 async function fetchRows(portalId, tableId) {
   return http.get(portalId, {
     uri: `${HUBDB_API_PATH}/tables/${tableId}/rows`,
@@ -14,6 +35,9 @@ async function fetchRows(portalId, tableId) {
 }
 
 module.exports = {
+  createTable,
+  updateRows,
+  createRows,
   fetchTables,
   fetchRows,
 };

--- a/packages/cms-lib/hubdb.js
+++ b/packages/cms-lib/hubdb.js
@@ -1,0 +1,60 @@
+const path = require('path');
+const fs = require('fs-extra');
+
+const { createTable, createRows } = require('./api/hubdb');
+
+async function createHubDbTable(portalId, src) {
+  try {
+    const stats = fs.statSync(src);
+    if (!stats.isFile()) {
+      throw new Error(`The "${src}" path is not a path to a file`);
+    }
+  } catch (e) {
+    throw new Error(`The "${src}" path is not a path to a file`);
+  }
+
+  if (path.extname(src) !== '.json') {
+    throw new Error('The HubDB table file must be a ".json" file');
+  }
+
+  const table = fs.readJsonSync(src);
+  const { rows, ...schema } = table;
+
+  const { columns, id } = await createTable(portalId, schema);
+
+  const rowsToUpdate = rows.map(row => {
+    const values = {};
+
+    columns.forEach(col => {
+      const { name, id } = col;
+      if (typeof row.values[name] !== 'undefined') {
+        values[id] = row.values[name];
+      } else {
+        values[id] = null;
+      }
+    });
+    return {
+      childTableId: 0,
+      isSoftEditable: false,
+      ...row,
+      values,
+    };
+  });
+
+  let response;
+  if (rowsToUpdate.length > 0) {
+    response = await createRows(portalId, id, rowsToUpdate);
+  }
+
+  return {
+    tableId: id,
+    rowCount:
+      response && Array.isArray(response) && response.length
+        ? response[0].rows.length
+        : 0,
+  };
+}
+
+module.exports = {
+  createHubDbTable,
+};

--- a/packages/cms-lib/hubdb.js
+++ b/packages/cms-lib/hubdb.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const fs = require('fs-extra');
 
-const { createTable, createRows } = require('./api/hubdb');
+const { createTable, createRows, publishTable } = require('./api/hubdb');
 
 async function createHubDbTable(portalId, src) {
   try {
@@ -45,6 +45,8 @@ async function createHubDbTable(portalId, src) {
   if (rowsToUpdate.length > 0) {
     response = await createRows(portalId, id, rowsToUpdate);
   }
+
+  await publishTable(portalId, id);
 
   return {
     tableId: id,


### PR DESCRIPTION
This PR will add an initial set of commands for working with HubDB tables and proposes a JSON structure for representing a table on the file system.

The structure avoids the awkwardness of column ids being used in values object for each row and combines the table structure with the rows into a single object. The current proposal is:

```json
{
  "name": "test",
  "columns": [
    {
      "label": "First name",
      "name": "firstName",
      "type": "TEXT"
    },
    {
      "label": "Last name",
      "name": "lastName",
      "type": "TEXT"
    },
    {
      "label": "Photo",
      "name": "photo",
      "type": "IMAGE"
    },
    {
      "label": "Bio",
      "name": "bio",
      "type": "RICHTEXT"
    }
  ],
  "rows": [
    {
      "path": null,
      "name": null,
      "values": {
        "firstName": "John",
        "lastName": "Smith",
        "bio": "A non-descript person of the world."
      }
    },
    {
      "path": null,
      "name": null,
      "values": {
        "firstName": "Cookie",
        "lastName": "Monster",
        "bio": "He likes cookies"
      }
    }
  ]
}
```

That said to minimize overloading, I may switch to something like:

```json
{
  "schema": {},
  "rows": {}
}
```

@anthmatic @axellabs @boulter 