### PR TITLE
Added oauth functionality to hs init command and made it the default

### DIFF
--- a/packages/cms-cli/commands/auth.js
+++ b/packages/cms-cli/commands/auth.js
@@ -69,6 +69,15 @@ const addOauthToPortalConfig = (oauth, portalId) => {
   }
 };
 
+const addNewAuthorizedOauthToConfig = async () => {
+  const answers = await getAuthContext();
+  const portalId = parseInt(answers.portalId, 10);
+  const oauth = setupOauth(answers, portalId);
+
+  await authorizeOauth(oauth);
+  addOauthToPortalConfig(oauth, portalId);
+};
+
 async function authAction(type, options) {
   setLogLevel(options);
   logDebugInfo(options);
@@ -85,13 +94,9 @@ async function authAction(type, options) {
     );
     return;
   }
-  const answers = await getAuthContext();
-  const portalId = parseInt(answers.portalId, 10);
-  const oauth = setupOauth(answers, portalId);
 
   trackCommandUsage(COMMAND_NAME);
-  authorizeOauth(oauth);
-  addOauthToPortalConfig(oauth, portalId);
+  await addNewAuthorizedOauthToConfig();
 }
 
 function configureAuthCommand(program) {

--- a/packages/cms-cli/commands/auth.js
+++ b/packages/cms-cli/commands/auth.js
@@ -70,6 +70,7 @@ function configureAuthCommand(program) {
           portalId: answers.portalId,
         });
         logger.log('Configuration updated');
+        process.exit();
       } catch (err) {
         logErrorInstance(err);
       }

--- a/packages/cms-cli/commands/auth.js
+++ b/packages/cms-cli/commands/auth.js
@@ -1,5 +1,4 @@
 const { version } = require('../package.json');
-const inquirer = require('inquirer');
 const OAuth2Manager = require('@hubspot/api-auth-lib/OAuth2Manager');
 const {
   loadConfig,
@@ -21,21 +20,10 @@ const {
   trackCommandUsage,
   addHelpUsageTracking,
 } = require('../lib/usageTracking');
-const {
-  PORTAL_NAME,
-  PORTAL_ID,
-  CLIENT_ID,
-  CLIENT_SECRET,
-} = require('../lib/prompts');
+const { promptUser, OAUTH_FLOW } = require('../lib/prompts');
 
 const COMMAND_NAME = 'auth';
-
 const REQUIRED_SCOPES = ['content'];
-
-const getAuthContext = async () => {
-  const prompt = inquirer.createPromptModule();
-  return prompt([PORTAL_NAME, PORTAL_ID, CLIENT_ID, CLIENT_SECRET]);
-};
 
 const setupOauth = (answers, portalId) => {
   const config = getPortalConfig(portalId) || {};
@@ -70,7 +58,7 @@ const addOauthToPortalConfig = (oauth, portalId) => {
 };
 
 const addNewAuthorizedOauthToConfig = async () => {
-  const answers = await getAuthContext();
+  const answers = await promptUser(OAUTH_FLOW);
   const portalId = parseInt(answers.portalId, 10);
   const oauth = setupOauth(answers, portalId);
 

--- a/packages/cms-cli/commands/auth.js
+++ b/packages/cms-cli/commands/auth.js
@@ -2,10 +2,7 @@ const { version } = require('../package.json');
 const { loadConfig } = require('@hubspot/cms-lib');
 const { logger } = require('@hubspot/cms-lib/logger');
 const { AUTH_METHODS } = require('@hubspot/cms-lib/lib/constants');
-const {
-  setupOauth,
-  addOauthToPortalConfig,
-} = require('@hubspot/cms-lib/oauth');
+const { authenticateWithOauth } = require('@hubspot/cms-lib/oauth');
 
 const { validateConfig } = require('../lib/validation');
 const {
@@ -21,18 +18,6 @@ const {
 const { promptUser, OAUTH_FLOW } = require('../lib/prompts');
 
 const COMMAND_NAME = 'auth';
-const REQUIRED_SCOPES = ['content'];
-
-const addNewAuthorizedOauthToConfig = async configData => {
-  const portalId = parseInt(configData.portalId, 10);
-  const oauth = setupOauth(portalId, {
-    ...configData,
-    scopes: REQUIRED_SCOPES,
-  });
-  logger.log('Authorizing');
-  await oauth.authorize();
-  addOauthToPortalConfig(portalId, oauth);
-};
 
 async function authAction(type, options) {
   setLogLevel(options);
@@ -53,7 +38,8 @@ async function authAction(type, options) {
 
   const configData = await promptUser(OAUTH_FLOW);
   trackCommandUsage(COMMAND_NAME);
-  await addNewAuthorizedOauthToConfig(configData);
+  await authenticateWithOauth(configData);
+  process.exit();
 }
 
 function configureAuthCommand(program) {
@@ -70,5 +56,4 @@ function configureAuthCommand(program) {
 
 module.exports = {
   configureAuthCommand,
-  addNewAuthorizedOauthToConfig,
 };

--- a/packages/cms-cli/commands/auth.js
+++ b/packages/cms-cli/commands/auth.js
@@ -30,6 +30,8 @@ const {
 
 const COMMAND_NAME = 'auth';
 
+const REQUIRED_SCOPES = ['content'];
+
 const getAuthContext = async () => {
   const prompt = inquirer.createPromptModule();
   return prompt([PORTAL_NAME, PORTAL_ID, CLIENT_ID, CLIENT_SECRET]);
@@ -41,7 +43,7 @@ const setupOauth = (answers, portalId) => {
     {
       ...answers,
       environment: config.env || 'prod',
-      scopes: ['content'],
+      scopes: REQUIRED_SCOPES,
     },
     logger
   );

--- a/packages/cms-cli/commands/auth.js
+++ b/packages/cms-cli/commands/auth.js
@@ -1,13 +1,11 @@
 const { version } = require('../package.json');
-const OAuth2Manager = require('@hubspot/api-auth-lib/OAuth2Manager');
-const {
-  loadConfig,
-  getPortalConfig,
-  updatePortalConfig,
-} = require('@hubspot/cms-lib');
-const { logErrorInstance } = require('@hubspot/cms-lib/errorHandlers');
+const { loadConfig } = require('@hubspot/cms-lib');
 const { logger } = require('@hubspot/cms-lib/logger');
 const { AUTH_METHODS } = require('@hubspot/cms-lib/lib/constants');
+const {
+  setupOauth,
+  addOauthToPortalConfig,
+} = require('@hubspot/cms-lib/oauth');
 
 const { validateConfig } = require('../lib/validation');
 const {
@@ -25,45 +23,15 @@ const { promptUser, OAUTH_FLOW } = require('../lib/prompts');
 const COMMAND_NAME = 'auth';
 const REQUIRED_SCOPES = ['content'];
 
-const setupOauth = (answers, portalId) => {
-  const config = getPortalConfig(portalId) || {};
-  return new OAuth2Manager(
-    {
-      ...answers,
-      environment: config.env || 'prod',
-      scopes: REQUIRED_SCOPES,
-    },
-    logger
-  );
-};
-
-const authorizeOauth = async oauth => {
+const addNewAuthorizedOauthToConfig = async configData => {
+  const portalId = parseInt(configData.portalId, 10);
+  const oauth = setupOauth(portalId, {
+    ...configData,
+    scopes: REQUIRED_SCOPES,
+  });
   logger.log('Authorizing');
   await oauth.authorize();
-};
-
-const addOauthToPortalConfig = (oauth, portalId) => {
-  logger.log('Updating configuration');
-  try {
-    updatePortalConfig({
-      ...oauth.toObj(),
-      authType: AUTH_METHODS.oauth.value,
-      portalId,
-    });
-    logger.log('Configuration updated');
-    process.exit();
-  } catch (err) {
-    logErrorInstance(err);
-  }
-};
-
-const addNewAuthorizedOauthToConfig = async () => {
-  const answers = await promptUser(OAUTH_FLOW);
-  const portalId = parseInt(answers.portalId, 10);
-  const oauth = setupOauth(answers, portalId);
-
-  await authorizeOauth(oauth);
-  addOauthToPortalConfig(oauth, portalId);
+  addOauthToPortalConfig(portalId, oauth);
 };
 
 async function authAction(type, options) {
@@ -83,8 +51,9 @@ async function authAction(type, options) {
     return;
   }
 
+  const configData = await promptUser(OAUTH_FLOW);
   trackCommandUsage(COMMAND_NAME);
-  await addNewAuthorizedOauthToConfig();
+  await addNewAuthorizedOauthToConfig(configData);
 }
 
 function configureAuthCommand(program) {
@@ -101,5 +70,5 @@ function configureAuthCommand(program) {
 
 module.exports = {
   configureAuthCommand,
-  authAction,
+  addNewAuthorizedOauthToConfig,
 };

--- a/packages/cms-cli/commands/init.js
+++ b/packages/cms-cli/commands/init.js
@@ -5,6 +5,7 @@ const {
   getConfigPath,
   writeNewPortalApiKeyConfig,
   createEmptyConfigFile,
+  deleteEmptyConfigFile,
 } = require('@hubspot/cms-lib/lib/config');
 const {
   logFileSystemErrorInstance,
@@ -33,10 +34,12 @@ const promptUser = async promptConfig => {
 const oauthConfigSetup = () => {
   try {
     createEmptyConfigFile();
-    spawn(HS_AUTH_OAUTH_COMMAND, {
+    const authProcess = spawn(HS_AUTH_OAUTH_COMMAND, {
       stdio: 'inherit',
       shell: true,
     });
+
+    authProcess.on('close', deleteEmptyConfigFile);
   } catch (e) {
     logErrorInstance(e, HS_AUTH_OAUTH_COMMAND);
   }

--- a/packages/cms-cli/commands/init.js
+++ b/packages/cms-cli/commands/init.js
@@ -25,14 +25,10 @@ const { logDebugInfo } = require('../lib/debugInfo');
 
 const COMMAND_NAME = 'init';
 const HS_AUTH_OAUTH_COMMAND = 'hs auth oauth2';
-const SPLIT_ON_CAPITALS_REGEX = /(?=[A-Z])/;
+const CAPITAL_LETTER_REGEX = /(?=[A-Z])/;
 const AUTH_METHODS = {
   oauth: 'oauth2',
   api: 'apiKey',
-};
-const AUTH_DESCRIPTIONS = {
-  [AUTH_METHODS.oauth]: `Initialize ${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME} using ${AUTH_METHODS.oauth}`,
-  [AUTH_METHODS.api]: `Initialize ${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME} using ${AUTH_METHODS.api}`,
 };
 
 const AUTH_METHOD_PROMPT_CONFIG = {
@@ -45,7 +41,7 @@ const AUTH_METHOD_PROMPT_CONFIG = {
     return {
       value: authMethod,
       name: authMethod
-        .split(SPLIT_ON_CAPITALS_REGEX)
+        .split(CAPITAL_LETTER_REGEX)
         .join(' ')
         .toLowerCase(),
     };
@@ -96,10 +92,16 @@ function initializeConfigCommand(program) {
   program
     .version(version)
     .description(
-      `Initialize ${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME} for a HubSpot portal`
+      `initialize ${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME} for a HubSpot portal`
     )
-    .option('--api', AUTH_DESCRIPTIONS.api)
-    .option('--oauth', AUTH_DESCRIPTIONS.oauth)
+    .option(
+      '--api',
+      `initialize ${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME} using ${AUTH_METHODS.api}`
+    )
+    .option(
+      '--oauth',
+      `initialize ${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME} using ${AUTH_METHODS.oauth}`
+    )
     .action(async options => {
       setLogLevel(options);
       logDebugInfo(options);

--- a/packages/cms-cli/commands/init.js
+++ b/packages/cms-cli/commands/init.js
@@ -1,11 +1,14 @@
 const { version } = require('../package.json');
 const inquirer = require('inquirer');
+const { spawn } = require('child_process');
 const {
   getConfigPath,
   writeNewPortalApiKeyConfig,
+  createEmptyConfigFile,
 } = require('@hubspot/cms-lib/lib/config');
 const {
   logFileSystemErrorInstance,
+  logErrorInstance,
 } = require('@hubspot/cms-lib/errorHandlers');
 const {
   DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
@@ -20,10 +23,44 @@ const { addLoggerOptions, setLogLevel } = require('../lib/commonOpts');
 const { logDebugInfo } = require('../lib/debugInfo');
 
 const COMMAND_NAME = 'init';
+const HS_AUTH_OAUTH_COMMAND = 'hs auth oauth2';
 
 const promptUser = async promptConfig => {
   const prompt = inquirer.createPromptModule();
   return prompt(promptConfig);
+};
+
+const oauthConfigSetup = () => {
+  try {
+    createEmptyConfigFile();
+    spawn(HS_AUTH_OAUTH_COMMAND, {
+      stdio: 'inherit',
+      shell: true,
+    });
+  } catch (e) {
+    logErrorInstance(e, HS_AUTH_OAUTH_COMMAND);
+  }
+
+  trackCommandUsage(COMMAND_NAME, {
+    authType: 'oauth',
+  });
+};
+
+const apiKeyConfigSetup = async ({ configPath }) => {
+  const configData = await promptUser([PORTAL_NAME, PORTAL_ID, PORTAL_API_KEY]);
+
+  try {
+    writeNewPortalApiKeyConfig(configData);
+  } catch (err) {
+    logFileSystemErrorInstance(err, {
+      filepath: configPath,
+      configData,
+    });
+  }
+
+  trackCommandUsage(COMMAND_NAME, {
+    authType: 'apiKey',
+  });
 };
 
 function initializeConfigCommand(program) {
@@ -31,6 +68,10 @@ function initializeConfigCommand(program) {
     .version(version)
     .description(
       `Initialize ${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME} for a HubSpot portal`
+    )
+    .option(
+      '--api',
+      `create ${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME} using API key for authentication`
     )
     .action(async options => {
       setLogLevel(options);
@@ -43,21 +84,15 @@ function initializeConfigCommand(program) {
         process.exit(1);
       }
 
-      const configData = await promptUser([
-        PORTAL_NAME,
-        PORTAL_ID,
-        PORTAL_API_KEY,
-      ]);
-
-      try {
-        writeNewPortalApiKeyConfig(configData);
-      } catch (err) {
-        logFileSystemErrorInstance(err, {
-          filepath: configPath,
-          configData,
+      if (options.api) {
+        apiKeyConfigSetup({
+          configPath,
+        });
+      } else {
+        oauthConfigSetup({
+          options,
         });
       }
-      trackCommandUsage(COMMAND_NAME);
     });
 
   addLoggerOptions(program);

--- a/packages/cms-cli/commands/init.js
+++ b/packages/cms-cli/commands/init.js
@@ -40,14 +40,14 @@ const oauthConfigSetup = async ({ options }) => {
   try {
     createEmptyConfigFile();
     process.on('exit', deleteEmptyConfigFile);
-    await authAction(AUTH_METHODS.oauth, options);
+    await authAction(AUTH_METHODS.oauth.value, options);
   } catch (e) {
     deleteEmptyConfigFile();
-    logErrorInstance(e, AUTH_METHODS.oauth);
+    logErrorInstance(e, AUTH_METHODS.oauth.value);
   }
 
   trackCommandUsage(COMMAND_NAME, {
-    authType: AUTH_METHODS.oauth,
+    authType: AUTH_METHODS.oauth.value,
   });
 };
 
@@ -64,7 +64,7 @@ const apiKeyConfigSetup = async ({ configPath }) => {
   }
 
   trackCommandUsage(COMMAND_NAME, {
-    authType: AUTH_METHODS.api,
+    authType: AUTH_METHODS.api.value,
   });
 };
 
@@ -74,40 +74,27 @@ function initializeConfigCommand(program) {
     .description(
       `initialize ${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME} for a HubSpot portal`
     )
-    .option(
-      '--api',
-      `initialize ${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME} using ${AUTH_METHODS.api}`
-    )
-    .option(
-      '--oauth',
-      `initialize ${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME} using ${AUTH_METHODS.oauth}`
-    )
     .action(async options => {
       setLogLevel(options);
       logDebugInfo(options);
 
       const configPath = getConfigPath();
-      let authMethod;
 
       if (configPath) {
         logger.error(`The config file '${configPath}' already exists.`);
         process.exit(1);
       }
 
-      if (!options.api && !options.oauth) {
-        ({ authMethod } = await promptUser(AUTH_METHOD));
-      }
+      const { authMethod } = await promptUser(AUTH_METHOD);
 
-      if (options.api || authMethod === AUTH_METHODS.api) {
+      if (authMethod === AUTH_METHODS.api.value) {
         return apiKeyConfigSetup({
           configPath,
         });
-      } else if (options.oauth || authMethod === AUTH_METHODS.oauth) {
+      } else if (authMethod === AUTH_METHODS.oauth.value) {
         return oauthConfigSetup({
           options,
         });
-      } else {
-        logErrorInstance('Unrecognized auth method passed to hs init');
       }
     });
 

--- a/packages/cms-cli/commands/init.js
+++ b/packages/cms-cli/commands/init.js
@@ -14,6 +14,7 @@ const {
   AUTH_METHODS,
 } = require('@hubspot/cms-lib/lib/constants');
 const { logger } = require('@hubspot/cms-lib/logger');
+const { authenticateWithOauth } = require('@hubspot/cms-lib/oauth');
 const {
   trackCommandUsage,
   addHelpUsageTracking,
@@ -26,7 +27,6 @@ const {
 } = require('../lib/prompts');
 const { addLoggerOptions, setLogLevel } = require('../lib/commonOpts');
 const { logDebugInfo } = require('../lib/debugInfo');
-const { addNewAuthorizedOauthToConfig } = require('./auth');
 
 const COMMAND_NAME = 'init';
 
@@ -36,7 +36,8 @@ const oauthConfigSetup = async ({ configPath }) => {
   try {
     createEmptyConfigFile();
     process.on('exit', deleteEmptyConfigFile);
-    await addNewAuthorizedOauthToConfig(configData);
+    await authenticateWithOauth(configData);
+    process.exit();
   } catch (err) {
     logFileSystemErrorInstance(err, {
       filepath: configPath,

--- a/packages/cms-cli/commands/init.js
+++ b/packages/cms-cli/commands/init.js
@@ -1,5 +1,4 @@
 const { version } = require('../package.json');
-const inquirer = require('inquirer');
 const {
   getConfigPath,
   updatePortalConfig,
@@ -20,22 +19,12 @@ const {
   trackCommandUsage,
   addHelpUsageTracking,
 } = require('../lib/usageTracking');
-const {
-  PORTAL_API_KEY,
-  PORTAL_ID,
-  PORTAL_NAME,
-  AUTH_METHOD,
-} = require('../lib/prompts');
+const { promptUser, API_KEY_FLOW, AUTH_METHOD } = require('../lib/prompts');
 const { addLoggerOptions, setLogLevel } = require('../lib/commonOpts');
 const { logDebugInfo } = require('../lib/debugInfo');
 const { authAction } = require('./auth');
 
 const COMMAND_NAME = 'init';
-
-const promptUser = async promptConfig => {
-  const prompt = inquirer.createPromptModule();
-  return prompt(promptConfig);
-};
 
 const oauthConfigSetup = async ({ options }) => {
   try {
@@ -53,7 +42,7 @@ const oauthConfigSetup = async ({ options }) => {
 };
 
 const apiKeyConfigSetup = async ({ configPath }) => {
-  const configData = await promptUser([PORTAL_NAME, PORTAL_ID, PORTAL_API_KEY]);
+  const configData = await promptUser(API_KEY_FLOW);
 
   try {
     createEmptyConfigFile();

--- a/packages/cms-cli/commands/init.js
+++ b/packages/cms-cli/commands/init.js
@@ -2,7 +2,8 @@ const { version } = require('../package.json');
 const inquirer = require('inquirer');
 const {
   getConfigPath,
-  writeNewPortalApiKeyConfig,
+  updatePortalConfig,
+  updateDefaultPortal,
   createEmptyConfigFile,
   deleteEmptyConfigFile,
 } = require('@hubspot/cms-lib/lib/config');
@@ -55,7 +56,10 @@ const apiKeyConfigSetup = async ({ configPath }) => {
   const configData = await promptUser([PORTAL_NAME, PORTAL_ID, PORTAL_API_KEY]);
 
   try {
-    writeNewPortalApiKeyConfig(configData);
+    createEmptyConfigFile();
+    process.on('exit', deleteEmptyConfigFile);
+    updateDefaultPortal(configData.name);
+    updatePortalConfig(configData);
   } catch (err) {
     logFileSystemErrorInstance(err, {
       filepath: configPath,

--- a/packages/cms-cli/commands/init.js
+++ b/packages/cms-cli/commands/init.js
@@ -99,11 +99,11 @@ function initializeConfigCommand(program) {
       }
 
       if (options.api || authMethod === AUTH_METHODS.api) {
-        apiKeyConfigSetup({
+        return apiKeyConfigSetup({
           configPath,
         });
       } else if (options.oauth || authMethod === AUTH_METHODS.oauth) {
-        oauthConfigSetup({
+        return oauthConfigSetup({
           options,
         });
       } else {

--- a/packages/cms-cli/commands/init.js
+++ b/packages/cms-cli/commands/init.js
@@ -24,7 +24,26 @@ const { addLoggerOptions, setLogLevel } = require('../lib/commonOpts');
 const { logDebugInfo } = require('../lib/debugInfo');
 
 const COMMAND_NAME = 'init';
+const AUTH_METHODS = {
+  api: 'apiKey',
+  oauth: 'oauth2',
+};
 const HS_AUTH_OAUTH_COMMAND = 'hs auth oauth2';
+
+const AUTH_METHOD_PROMPT_CONFIG = {
+  type: 'list',
+  name: 'authMethod',
+  choices: [
+    {
+      value: AUTH_METHODS.oauth,
+      name: `Initialize ${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME} using ${AUTH_METHODS.oauth}`,
+    },
+    {
+      value: AUTH_METHODS.api,
+      name: `Initialize ${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME} using ${AUTH_METHODS.api}`,
+    },
+  ],
+};
 
 const promptUser = async promptConfig => {
   const prompt = inquirer.createPromptModule();
@@ -45,7 +64,7 @@ const oauthConfigSetup = () => {
   }
 
   trackCommandUsage(COMMAND_NAME, {
-    authType: 'oauth',
+    authType: AUTH_METHODS.oauth,
   });
 };
 
@@ -62,7 +81,7 @@ const apiKeyConfigSetup = async ({ configPath }) => {
   }
 
   trackCommandUsage(COMMAND_NAME, {
-    authType: 'apiKey',
+    authType: AUTH_METHODS.api,
   });
 };
 
@@ -87,7 +106,9 @@ function initializeConfigCommand(program) {
         process.exit(1);
       }
 
-      if (options.api) {
+      const { authMethod } = await promptUser(AUTH_METHOD_PROMPT_CONFIG);
+
+      if (authMethod === AUTH_METHODS.api) {
         apiKeyConfigSetup({
           configPath,
         });

--- a/packages/cms-cli/commands/init.js
+++ b/packages/cms-cli/commands/init.js
@@ -25,28 +25,31 @@ const { logDebugInfo } = require('../lib/debugInfo');
 
 const COMMAND_NAME = 'init';
 const HS_AUTH_OAUTH_COMMAND = 'hs auth oauth2';
+const SPLIT_ON_CAPITALS_REGEX = /(?=[A-Z])/;
 const AUTH_METHODS = {
-  api: 'apiKey',
   oauth: 'oauth2',
+  api: 'apiKey',
 };
 const AUTH_DESCRIPTIONS = {
-  [AUTH_METHODS.api]: `Initialize ${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME} using ${AUTH_METHODS.api}`,
   [AUTH_METHODS.oauth]: `Initialize ${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME} using ${AUTH_METHODS.oauth}`,
+  [AUTH_METHODS.api]: `Initialize ${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME} using ${AUTH_METHODS.api}`,
 };
 
 const AUTH_METHOD_PROMPT_CONFIG = {
   type: 'list',
   name: 'authMethod',
-  choices: [
-    {
-      value: AUTH_METHODS.oauth,
-      name: AUTH_DESCRIPTIONS.oauth,
-    },
-    {
-      value: AUTH_METHODS.api,
-      name: AUTH_DESCRIPTIONS.api,
-    },
-  ],
+  message: 'Choose authentication method',
+  default: AUTH_METHODS.oauth,
+  choices: Object.keys(AUTH_METHODS).map(method => {
+    const authMethod = AUTH_METHODS[method];
+    return {
+      value: authMethod,
+      name: authMethod
+        .split(SPLIT_ON_CAPITALS_REGEX)
+        .join(' ')
+        .toLowerCase(),
+    };
+  }),
 };
 
 const promptUser = async promptConfig => {
@@ -117,7 +120,7 @@ function initializeConfigCommand(program) {
         apiKeyConfigSetup({
           configPath,
         });
-      } else if (options.oauth || authMethod === AUTH_METHODS.api) {
+      } else if (options.oauth || authMethod === AUTH_METHODS.oauth) {
         oauthConfigSetup({
           options,
         });

--- a/packages/cms-cli/lib/prompts.js
+++ b/packages/cms-cli/lib/prompts.js
@@ -1,5 +1,11 @@
-const { API_KEY_REGEX } = require('./regex');
+const inquirer = require('inquirer');
 const { AUTH_METHODS } = require('@hubspot/cms-lib/lib/constants');
+const { API_KEY_REGEX } = require('./regex');
+
+const promptUser = async promptConfig => {
+  const prompt = inquirer.createPromptModule();
+  return prompt(promptConfig);
+};
 
 const PORTAL_ID = {
   name: 'portalId',
@@ -67,11 +73,17 @@ const AUTH_METHOD = {
   choices: Object.keys(AUTH_METHODS).map(method => AUTH_METHODS[method]),
 };
 
+const OAUTH_FLOW = [PORTAL_NAME, PORTAL_ID, CLIENT_ID, CLIENT_SECRET];
+const API_KEY_FLOW = [PORTAL_NAME, PORTAL_ID, PORTAL_API_KEY];
+
 module.exports = {
+  promptUser,
   PORTAL_API_KEY,
   PORTAL_ID,
   PORTAL_NAME,
   CLIENT_ID,
   CLIENT_SECRET,
   AUTH_METHOD,
+  OAUTH_FLOW,
+  API_KEY_FLOW,
 };

--- a/packages/cms-cli/lib/prompts.js
+++ b/packages/cms-cli/lib/prompts.js
@@ -1,4 +1,5 @@
-const API_KEY_REGEX = /^([a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})$/i;
+const { API_KEY_REGEX, CAPITAL_LETTER_REGEX } = require('./regex');
+const { AUTH_METHODS } = require('@hubspot/cms-lib/lib/constants');
 
 const PORTAL_ID = {
   name: 'portalId',
@@ -58,10 +59,28 @@ const PORTAL_API_KEY = {
   },
 };
 
+const AUTH_METHOD = {
+  type: 'list',
+  name: 'authMethod',
+  message: 'Choose authentication method',
+  default: AUTH_METHODS.oauth,
+  choices: Object.keys(AUTH_METHODS).map(method => {
+    const authMethod = AUTH_METHODS[method];
+    return {
+      value: authMethod,
+      name: authMethod
+        .split(CAPITAL_LETTER_REGEX)
+        .join(' ')
+        .toLowerCase(),
+    };
+  }),
+};
+
 module.exports = {
   PORTAL_API_KEY,
   PORTAL_ID,
   PORTAL_NAME,
   CLIENT_ID,
   CLIENT_SECRET,
+  AUTH_METHOD,
 };

--- a/packages/cms-cli/lib/prompts.js
+++ b/packages/cms-cli/lib/prompts.js
@@ -1,4 +1,4 @@
-const { API_KEY_REGEX, CAPITAL_LETTER_REGEX } = require('./regex');
+const { API_KEY_REGEX } = require('./regex');
 const { AUTH_METHODS } = require('@hubspot/cms-lib/lib/constants');
 
 const PORTAL_ID = {
@@ -63,17 +63,8 @@ const AUTH_METHOD = {
   type: 'list',
   name: 'authMethod',
   message: 'Choose authentication method',
-  default: AUTH_METHODS.oauth,
-  choices: Object.keys(AUTH_METHODS).map(method => {
-    const authMethod = AUTH_METHODS[method];
-    return {
-      value: authMethod,
-      name: authMethod
-        .split(CAPITAL_LETTER_REGEX)
-        .join(' ')
-        .toLowerCase(),
-    };
-  }),
+  default: AUTH_METHODS.oauth.value,
+  choices: Object.keys(AUTH_METHODS).map(method => AUTH_METHODS[method]),
 };
 
 module.exports = {

--- a/packages/cms-cli/lib/prompts.js
+++ b/packages/cms-cli/lib/prompts.js
@@ -73,7 +73,7 @@ const AUTH_METHOD = {
   choices: Object.keys(AUTH_METHODS).map(method => AUTH_METHODS[method]),
 };
 
-const OAUTH_FLOW = [PORTAL_NAME, PORTAL_ID, CLIENT_ID, CLIENT_SECRET];
+const OAUTH_FLOW = [PORTAL_ID, CLIENT_ID, CLIENT_SECRET];
 const API_KEY_FLOW = [PORTAL_NAME, PORTAL_ID, PORTAL_API_KEY];
 
 module.exports = {

--- a/packages/cms-cli/lib/regex.js
+++ b/packages/cms-cli/lib/regex.js
@@ -1,8 +1,5 @@
 const API_KEY_REGEX = /^([a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})$/i;
 
-const CAPITAL_LETTER_REGEX = /(?=[A-Z])/;
-
 module.exports = {
   API_KEY_REGEX,
-  CAPITAL_LETTER_REGEX,
 };

--- a/packages/cms-cli/lib/regex.js
+++ b/packages/cms-cli/lib/regex.js
@@ -1,0 +1,8 @@
+const API_KEY_REGEX = /^([a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})$/i;
+
+const CAPITAL_LETTER_REGEX = /(?=[A-Z])/;
+
+module.exports = {
+  API_KEY_REGEX,
+  CAPITAL_LETTER_REGEX,
+};

--- a/packages/cms-lib/lib/config.js
+++ b/packages/cms-lib/lib/config.js
@@ -69,11 +69,7 @@ const loadConfig = path => {
   _config = parsed;
 
   if (!_config) {
-    logger.debug('The config file was empty config');
-    logger.debug('Initializing an empty config');
-    _config = {
-      portals: [],
-    };
+    initializeEmptyConfig();
   }
 };
 
@@ -204,9 +200,13 @@ const updatePortalConfig = configOptions => {
   writeConfig();
 };
 
+const setDefaultConfigPath = () => {
+  setConfigPath(`${getCwd()}/${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME}`);
+};
+
 const writeNewPortalApiKeyConfig = configOptions => {
   setConfig(getNewPortalApiKeyConfig(configOptions));
-  setConfigPath(`${getCwd()}/${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME}`);
+  setDefaultConfigPath();
   writeConfig();
 };
 
@@ -226,6 +226,19 @@ const getNewPortalApiKeyConfig = ({ name, portalId, apiKey, environment }) => {
   };
 };
 
+const initializeEmptyConfig = () => {
+  logger.debug('The config file was empty config');
+  logger.debug('Initializing an empty config');
+  _config = {
+    portals: [],
+  };
+};
+
+const createEmptyConfigFile = () => {
+  setDefaultConfigPath();
+  fs.writeFileSync(_configPath, '');
+};
+
 module.exports = {
   getAndLoadConfigIfNeeded,
   getConfig,
@@ -236,4 +249,5 @@ module.exports = {
   getPortalId,
   updatePortalConfig,
   writeNewPortalApiKeyConfig,
+  createEmptyConfigFile,
 };

--- a/packages/cms-lib/lib/config.js
+++ b/packages/cms-lib/lib/config.js
@@ -69,7 +69,11 @@ const loadConfig = path => {
   _config = parsed;
 
   if (!_config) {
-    initializeEmptyConfig();
+    logger.debug('The config file was empty config');
+    logger.debug('Initializing an empty config');
+    _config = {
+      portals: [],
+    };
   }
 };
 
@@ -223,14 +227,6 @@ const getNewPortalApiKeyConfig = ({ name, portalId, apiKey, environment }) => {
         env: getConfigEnv(environment),
       },
     ],
-  };
-};
-
-const initializeEmptyConfig = () => {
-  logger.debug('The config file was empty config');
-  logger.debug('Initializing an empty config');
-  _config = {
-    portals: [],
   };
 };
 

--- a/packages/cms-lib/lib/config.js
+++ b/packages/cms-lib/lib/config.js
@@ -163,6 +163,8 @@ const updatePortalConfig = configOptions => {
     scopes,
     tokenInfo,
     defaultMode,
+    name,
+    apiKey,
   } = configOptions;
 
   if (!portalId) {
@@ -186,10 +188,12 @@ const updatePortalConfig = configOptions => {
   const mode = defaultMode && defaultMode.toLowerCase();
   const nextPortalConfig = {
     ...portalConfig,
+    name,
     env,
     portalId,
     authType,
     auth,
+    apiKey,
     defaultMode: Mode[mode] ? mode : undefined,
   };
 
@@ -208,30 +212,26 @@ const updatePortalConfig = configOptions => {
   writeConfig();
 };
 
-const setDefaultConfigPath = () => {
-  setConfigPath(`${getCwd()}/${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME}`);
-};
+/**
+ * @throws {Error}
+ */
+const updateDefaultPortal = defaultPortal => {
+  if (
+    !defaultPortal ||
+    (typeof defaultPortal !== 'number' && typeof defaultPortal !== 'string')
+  ) {
+    throw new Error(
+      'A defaultPortal with value of number or string is required to update the config'
+    );
+  }
 
-const writeNewPortalApiKeyConfig = configOptions => {
-  setConfig(getNewPortalApiKeyConfig(configOptions));
-  setDefaultConfigPath();
+  const config = getAndLoadConfigIfNeeded();
+  config.defaultPortal = defaultPortal;
   writeConfig();
 };
 
-const getNewPortalApiKeyConfig = ({ name, portalId, apiKey, environment }) => {
-  logger.log('Generating config data');
-  return {
-    defaultPortal: name,
-    portals: [
-      {
-        name,
-        portalId,
-        apiKey,
-        authType: 'apikey',
-        env: getConfigEnv(environment),
-      },
-    ],
-  };
+const setDefaultConfigPath = () => {
+  setConfigPath(`${getCwd()}/${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME}`);
 };
 
 const configFileExists = () => {
@@ -265,7 +265,7 @@ module.exports = {
   getPortalConfig,
   getPortalId,
   updatePortalConfig,
-  writeNewPortalApiKeyConfig,
+  updateDefaultPortal,
   createEmptyConfigFile,
   deleteEmptyConfigFile,
 };

--- a/packages/cms-lib/lib/config.js
+++ b/packages/cms-lib/lib/config.js
@@ -7,7 +7,11 @@ const {
   logFileSystemErrorInstance,
 } = require('../errorHandlers');
 const { getCwd } = require('../path');
-const { DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME, Mode } = require('./constants');
+const {
+  DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
+  EMPTY_CONFIG_FILE_CONTENTS,
+  Mode,
+} = require('./constants');
 
 let _config;
 let _configPath;
@@ -230,9 +234,26 @@ const getNewPortalApiKeyConfig = ({ name, portalId, apiKey, environment }) => {
   };
 };
 
+const configFileExists = () => {
+  return _configPath && fs.existsSync(_configPath);
+};
+
+const configFileIsBlank = () => {
+  return _configPath && fs.readFileSync(_configPath).length === 0;
+};
+
 const createEmptyConfigFile = () => {
-  setDefaultConfigPath();
-  fs.writeFileSync(_configPath, '');
+  if (!_configPath) {
+    setDefaultConfigPath();
+  }
+
+  return fs.writeFileSync(_configPath, EMPTY_CONFIG_FILE_CONTENTS);
+};
+
+const deleteEmptyConfigFile = () => {
+  return (
+    configFileExists() && configFileIsBlank() && fs.unlinkSync(_configPath)
+  );
 };
 
 module.exports = {
@@ -246,4 +267,5 @@ module.exports = {
   updatePortalConfig,
   writeNewPortalApiKeyConfig,
   createEmptyConfigFile,
+  deleteEmptyConfigFile,
 };

--- a/packages/cms-lib/lib/constants.js
+++ b/packages/cms-lib/lib/constants.js
@@ -45,6 +45,8 @@ const AUTH_METHODS = {
   },
 };
 
+const DEFAULT_OAUTH_SCOPES = ['content'];
+
 module.exports = {
   Mode,
   ALLOWED_EXTENSIONS,
@@ -54,4 +56,5 @@ module.exports = {
   DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
   EMPTY_CONFIG_FILE_CONTENTS,
   AUTH_METHODS,
+  DEFAULT_OAUTH_SCOPES,
 };

--- a/packages/cms-lib/lib/constants.js
+++ b/packages/cms-lib/lib/constants.js
@@ -34,6 +34,11 @@ const DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME = 'hubspot.config.yml';
 
 const EMPTY_CONFIG_FILE_CONTENTS = '';
 
+const AUTH_METHODS = {
+  oauth: 'oauth2',
+  api: 'apiKey',
+};
+
 module.exports = {
   Mode,
   ALLOWED_EXTENSIONS,
@@ -42,4 +47,5 @@ module.exports = {
   DEFAULT_MODE,
   DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
   EMPTY_CONFIG_FILE_CONTENTS,
+  AUTH_METHODS,
 };

--- a/packages/cms-lib/lib/constants.js
+++ b/packages/cms-lib/lib/constants.js
@@ -35,8 +35,14 @@ const DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME = 'hubspot.config.yml';
 const EMPTY_CONFIG_FILE_CONTENTS = '';
 
 const AUTH_METHODS = {
-  oauth: 'oauth2',
-  api: 'apiKey',
+  oauth: {
+    value: 'oauth2',
+    name: 'OAuth2',
+  },
+  api: {
+    value: 'apiKey',
+    name: 'API Key',
+  },
 };
 
 module.exports = {

--- a/packages/cms-lib/lib/constants.js
+++ b/packages/cms-lib/lib/constants.js
@@ -32,6 +32,8 @@ const DEFAULT_MODE = Mode.publish;
 
 const DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME = 'hubspot.config.yml';
 
+const EMPTY_CONFIG_FILE_CONTENTS = '';
+
 module.exports = {
   Mode,
   ALLOWED_EXTENSIONS,
@@ -39,4 +41,5 @@ module.exports = {
   MODULE_EXTENSION,
   DEFAULT_MODE,
   DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
+  EMPTY_CONFIG_FILE_CONTENTS,
 };

--- a/packages/cms-lib/oauth.js
+++ b/packages/cms-lib/oauth.js
@@ -1,6 +1,7 @@
 const OAuth2Manager = require('@hubspot/api-auth-lib/OAuth2Manager');
-const { updatePortalConfig } = require('./lib/config');
-const { logger } = require('./logger');
+const { updatePortalConfig, getPortalConfig } = require('./lib/config');
+const { logger, logErrorInstance } = require('./logger');
+const { AUTH_METHODS } = require('./lib/constants');
 
 const oauthManagers = new Map();
 
@@ -31,6 +32,34 @@ const getOauthManager = (portalId, portalConfig) => {
   return oauthManagers.get(portalId);
 };
 
+const setupOauth = (portalId, portalConfig) => {
+  const config = getPortalConfig(portalId) || {};
+  return new OAuth2Manager(
+    {
+      ...portalConfig,
+      environment: config.env || 'prod',
+    },
+    logger
+  );
+};
+
+const addOauthToPortalConfig = (portalId, oauth) => {
+  logger.log('Updating configuration');
+  try {
+    updatePortalConfig({
+      ...oauth.toObj(),
+      authType: AUTH_METHODS.oauth.value,
+      portalId,
+    });
+    logger.log('Configuration updated');
+    process.exit();
+  } catch (err) {
+    logErrorInstance(err);
+  }
+};
+
 module.exports = {
   getOauthManager,
+  setupOauth,
+  addOauthToPortalConfig,
 };

--- a/packages/cms-lib/oauth.js
+++ b/packages/cms-lib/oauth.js
@@ -1,7 +1,7 @@
 const OAuth2Manager = require('@hubspot/api-auth-lib/OAuth2Manager');
 const { updatePortalConfig, getPortalConfig } = require('./lib/config');
 const { logger, logErrorInstance } = require('./logger');
-const { AUTH_METHODS } = require('./lib/constants');
+const { AUTH_METHODS, DEFAULT_OAUTH_SCOPES } = require('./lib/constants');
 
 const oauthManagers = new Map();
 
@@ -52,14 +52,23 @@ const addOauthToPortalConfig = (portalId, oauth) => {
       portalId,
     });
     logger.log('Configuration updated');
-    process.exit();
   } catch (err) {
     logErrorInstance(err);
   }
 };
 
+const authenticateWithOauth = async configData => {
+  const portalId = parseInt(configData.portalId, 10);
+  const oauth = setupOauth(portalId, {
+    scopes: DEFAULT_OAUTH_SCOPES,
+    ...configData,
+  });
+  logger.log('Authorizing');
+  await oauth.authorize();
+  addOauthToPortalConfig(portalId, oauth);
+};
+
 module.exports = {
   getOauthManager,
-  setupOauth,
-  addOauthToPortalConfig,
+  authenticateWithOauth,
 };


### PR DESCRIPTION
Relates to #3 

This will help users generate an oauth based hubspot.config.yml file by creating a blank file and then leveraging the existing `hs auth oauth` command to prompt for config inputs.

Cancelling out of the prompt will remove the blank file that is created.
