### PR TITLE
Fixed tests, updated documentation, and added more tracking

### DIFF
--- a/packages/cms-cli/commands/auth.js
+++ b/packages/cms-cli/commands/auth.js
@@ -2,10 +2,7 @@ const { version } = require('../package.json');
 const { loadConfig } = require('@hubspot/cms-lib');
 const { logger } = require('@hubspot/cms-lib/logger');
 const { AUTH_METHODS } = require('@hubspot/cms-lib/lib/constants');
-const {
-  setupOauth,
-  addOauthToPortalConfig,
-} = require('@hubspot/cms-lib/oauth');
+const { authenticateWithOauth } = require('@hubspot/cms-lib/oauth');
 
 const { validateConfig } = require('../lib/validation');
 const {
@@ -21,18 +18,6 @@ const {
 const { promptUser, OAUTH_FLOW } = require('../lib/prompts');
 
 const COMMAND_NAME = 'auth';
-const REQUIRED_SCOPES = ['content'];
-
-const addNewAuthorizedOauthToConfig = async configData => {
-  const portalId = parseInt(configData.portalId, 10);
-  const oauth = setupOauth(portalId, {
-    ...configData,
-    scopes: REQUIRED_SCOPES,
-  });
-  logger.log('Authorizing');
-  await oauth.authorize();
-  addOauthToPortalConfig(portalId, oauth);
-};
 
 async function authAction(type, options) {
   setLogLevel(options);
@@ -53,7 +38,8 @@ async function authAction(type, options) {
 
   const configData = await promptUser(OAUTH_FLOW);
   trackCommandUsage(COMMAND_NAME);
-  await addNewAuthorizedOauthToConfig(configData);
+  await authenticateWithOauth(configData);
+  process.exit();
 }
 
 function configureAuthCommand(program) {
@@ -70,5 +56,4 @@ function configureAuthCommand(program) {
 
 module.exports = {
   configureAuthCommand,
-  addNewAuthorizedOauthToConfig,
 };

--- a/packages/cms-cli/commands/init.js
+++ b/packages/cms-cli/commands/init.js
@@ -4,7 +4,6 @@ const {
   updatePortalConfig,
   updateDefaultPortal,
   createEmptyConfigFile,
-  deleteEmptyConfigFile,
 } = require('@hubspot/cms-lib/lib/config');
 const {
   logFileSystemErrorInstance,
@@ -38,6 +37,9 @@ const oauthConfigSetup = async ({ configPath }) => {
   const configData = await promptUser(OAUTH_FLOW);
 
   try {
+    createEmptyConfigFile({
+      deleteOnExitIfBlank: true,
+    });
     await authenticateWithOauth(configData);
     process.exit();
   } catch (err) {
@@ -61,6 +63,9 @@ const apiKeyConfigSetup = async ({ configPath }) => {
   const configData = await promptUser(API_KEY_FLOW);
 
   try {
+    createEmptyConfigFile({
+      deleteOnExitIfBlank: true,
+    });
     updateDefaultPortal(configData.name);
     updatePortalConfig(configData);
   } catch (err) {
@@ -92,9 +97,6 @@ function initializeConfigCommand(program) {
         logger.error(`The config file '${configPath}' already exists.`);
         process.exit(1);
       }
-
-      createEmptyConfigFile();
-      process.on('exit', deleteEmptyConfigFile);
 
       const { authMethod } = await promptUser(AUTH_METHOD);
 

--- a/packages/cms-cli/commands/init.js
+++ b/packages/cms-cli/commands/init.js
@@ -28,12 +28,18 @@ const { addLoggerOptions, setLogLevel } = require('../lib/commonOpts');
 const { logDebugInfo } = require('../lib/debugInfo');
 
 const COMMAND_NAME = 'init';
+const TRACKING_STATUS = {
+  STARTED: 'started',
+  COMPLETE: 'complete',
+};
+
+const trackAuthMethodStatus = (authMethod, status) => {
+  return trackCommandUsage(`${authMethod} ${status}`);
+};
 
 const oauthConfigSetup = async ({ configPath }) => {
-  trackCommandUsage(COMMAND_NAME, {
-    authMethod: AUTH_METHODS.api.value,
-    status: 'started',
-  });
+  const authMethod = AUTH_METHODS.oauth.value;
+  trackAuthMethodStatus(authMethod, TRACKING_STATUS.STARTED);
   const configData = await promptUser(OAUTH_FLOW);
 
   try {
@@ -49,17 +55,12 @@ const oauthConfigSetup = async ({ configPath }) => {
     });
   }
 
-  trackCommandUsage(COMMAND_NAME, {
-    authMethod: AUTH_METHODS.oauth.value,
-    status: 'complete',
-  });
+  trackAuthMethodStatus(authMethod, TRACKING_STATUS.COMPLETE);
 };
 
 const apiKeyConfigSetup = async ({ configPath }) => {
-  trackCommandUsage(COMMAND_NAME, {
-    authMethod: AUTH_METHODS.api.value,
-    status: 'started',
-  });
+  const authMethod = AUTH_METHODS.api.value;
+  trackAuthMethodStatus(authMethod, TRACKING_STATUS.STARTED);
   const configData = await promptUser(API_KEY_FLOW);
 
   try {
@@ -75,10 +76,7 @@ const apiKeyConfigSetup = async ({ configPath }) => {
     });
   }
 
-  trackCommandUsage(COMMAND_NAME, {
-    authMethod: AUTH_METHODS.api.value,
-    status: 'complete',
-  });
+  trackAuthMethodStatus(authMethod, TRACKING_STATUS.COMPLETE);
 };
 
 function initializeConfigCommand(program) {
@@ -90,6 +88,7 @@ function initializeConfigCommand(program) {
     .action(async options => {
       setLogLevel(options);
       logDebugInfo(options);
+      trackCommandUsage(COMMAND_NAME);
 
       const configPath = getConfigPath();
 

--- a/packages/cms-cli/commands/init.js
+++ b/packages/cms-cli/commands/init.js
@@ -17,6 +17,7 @@ const { authenticateWithOauth } = require('@hubspot/cms-lib/oauth');
 const {
   trackCommandUsage,
   addHelpUsageTracking,
+  trackCommandAction,
 } = require('../lib/usageTracking');
 const {
   promptUser,
@@ -60,7 +61,7 @@ const AUTH_METHOD_FLOW = {
 };
 
 const trackAuthMethodStatus = (authMethod, status) => {
-  return trackCommandUsage(`${authMethod} ${status}`);
+  return trackCommandAction(COMMAND_NAME, `${authMethod} ${status}`);
 };
 
 const completeConfigSetup = async ({ authMethod, configPath }) => {

--- a/packages/cms-cli/commands/init.js
+++ b/packages/cms-cli/commands/init.js
@@ -31,6 +31,10 @@ const { logDebugInfo } = require('../lib/debugInfo');
 const COMMAND_NAME = 'init';
 
 const oauthConfigSetup = async ({ configPath }) => {
+  trackCommandUsage(COMMAND_NAME, {
+    authMethod: AUTH_METHODS.api.value,
+    status: 'started',
+  });
   const configData = await promptUser(OAUTH_FLOW);
 
   try {
@@ -46,11 +50,16 @@ const oauthConfigSetup = async ({ configPath }) => {
   }
 
   trackCommandUsage(COMMAND_NAME, {
-    authType: AUTH_METHODS.oauth.value,
+    authMethod: AUTH_METHODS.oauth.value,
+    status: 'complete',
   });
 };
 
 const apiKeyConfigSetup = async ({ configPath }) => {
+  trackCommandUsage(COMMAND_NAME, {
+    authMethod: AUTH_METHODS.api.value,
+    status: 'started',
+  });
   const configData = await promptUser(API_KEY_FLOW);
 
   try {
@@ -66,7 +75,8 @@ const apiKeyConfigSetup = async ({ configPath }) => {
   }
 
   trackCommandUsage(COMMAND_NAME, {
-    authType: AUTH_METHODS.api.value,
+    authMethod: AUTH_METHODS.api.value,
+    status: 'complete',
   });
 };
 

--- a/packages/cms-cli/commands/init.js
+++ b/packages/cms-cli/commands/init.js
@@ -14,6 +14,7 @@ const {
   AUTH_METHODS,
 } = require('@hubspot/cms-lib/lib/constants');
 const { logger } = require('@hubspot/cms-lib/logger');
+const { authenticateWithOauth } = require('@hubspot/cms-lib/oauth');
 const {
   trackCommandUsage,
   addHelpUsageTracking,
@@ -26,7 +27,6 @@ const {
 } = require('../lib/prompts');
 const { addLoggerOptions, setLogLevel } = require('../lib/commonOpts');
 const { logDebugInfo } = require('../lib/debugInfo');
-const { addNewAuthorizedOauthToConfig } = require('./auth');
 
 const COMMAND_NAME = 'init';
 
@@ -36,7 +36,8 @@ const oauthConfigSetup = async ({ configPath }) => {
   try {
     createEmptyConfigFile();
     process.on('exit', deleteEmptyConfigFile);
-    await addNewAuthorizedOauthToConfig(configData);
+    await authenticateWithOauth(configData);
+    process.exit();
   } catch (err) {
     logFileSystemErrorInstance(err, {
       filepath: configPath,

--- a/packages/cms-cli/commands/init.js
+++ b/packages/cms-cli/commands/init.js
@@ -38,8 +38,6 @@ const oauthConfigSetup = async ({ configPath }) => {
   const configData = await promptUser(OAUTH_FLOW);
 
   try {
-    createEmptyConfigFile();
-    process.on('exit', deleteEmptyConfigFile);
     await authenticateWithOauth(configData);
     process.exit();
   } catch (err) {
@@ -63,8 +61,6 @@ const apiKeyConfigSetup = async ({ configPath }) => {
   const configData = await promptUser(API_KEY_FLOW);
 
   try {
-    createEmptyConfigFile();
-    process.on('exit', deleteEmptyConfigFile);
     updateDefaultPortal(configData.name);
     updatePortalConfig(configData);
   } catch (err) {
@@ -96,6 +92,9 @@ function initializeConfigCommand(program) {
         logger.error(`The config file '${configPath}' already exists.`);
         process.exit(1);
       }
+
+      createEmptyConfigFile();
+      process.on('exit', deleteEmptyConfigFile);
 
       const { authMethod } = await promptUser(AUTH_METHOD);
 

--- a/packages/cms-cli/commands/init.js
+++ b/packages/cms-cli/commands/init.js
@@ -17,7 +17,7 @@ const { authenticateWithOauth } = require('@hubspot/cms-lib/oauth');
 const {
   trackCommandUsage,
   addHelpUsageTracking,
-  trackCommandAction,
+  trackAuthAction,
 } = require('../lib/usageTracking');
 const {
   promptUser,
@@ -60,13 +60,9 @@ const AUTH_METHOD_FLOW = {
   },
 };
 
-const trackAuthMethodStatus = (authMethod, status) => {
-  return trackCommandAction(COMMAND_NAME, `${authMethod} ${status}`);
-};
-
 const completeConfigSetup = async ({ authMethod, configPath }) => {
   const flow = AUTH_METHOD_FLOW[authMethod];
-  trackAuthMethodStatus(authMethod, TRACKING_STATUS.STARTED);
+  trackAuthAction(COMMAND_NAME, authMethod, TRACKING_STATUS.STARTED);
 
   try {
     flow.setup(await flow.prompt());
@@ -76,7 +72,7 @@ const completeConfigSetup = async ({ authMethod, configPath }) => {
     });
   }
 
-  trackAuthMethodStatus(authMethod, TRACKING_STATUS.COMPLETE);
+  trackAuthAction(COMMAND_NAME, authMethod, TRACKING_STATUS.COMPLETE);
 };
 
 function initializeConfigCommand(program) {

--- a/packages/cms-cli/commands/init.js
+++ b/packages/cms-cli/commands/init.js
@@ -4,6 +4,7 @@ const {
   updatePortalConfig,
   updateDefaultPortal,
   createEmptyConfigFile,
+  deleteEmptyConfigFile,
 } = require('@hubspot/cms-lib/lib/config');
 const {
   logFileSystemErrorInstance,
@@ -39,9 +40,8 @@ const AUTH_METHOD_FLOW = {
       return promptUser(API_KEY_FLOW);
     },
     setup: async configData => {
-      createEmptyConfigFile({
-        deleteOnExitIfBlank: true,
-      });
+      createEmptyConfigFile();
+      process.on('exit', deleteEmptyConfigFile);
       updateDefaultPortal(configData.name);
       updatePortalConfig(configData);
     },
@@ -51,9 +51,8 @@ const AUTH_METHOD_FLOW = {
       return promptUser(OAUTH_FLOW);
     },
     setup: async configData => {
-      createEmptyConfigFile({
-        deleteOnExitIfBlank: true,
-      });
+      createEmptyConfigFile();
+      process.on('exit', deleteEmptyConfigFile);
       await authenticateWithOauth(configData);
       process.exit();
     },

--- a/packages/cms-cli/lib/usageTracking.js
+++ b/packages/cms-cli/lib/usageTracking.js
@@ -75,13 +75,28 @@ const addHelpUsageTracking = (program, command) => {
   });
 };
 
-const trackCommandAction = (command, action, ...rest) => {
-  return trackCommandUsage(`${command}: ${action}`, ...rest);
+const trackAuthAction = async (command, authType, step) => {
+  if (!isTrackingAllowed()) {
+    return;
+  }
+  try {
+    return await trackUsage('cli-interaction', EventClass.INTERACTION, {
+      action: 'cli-auth',
+      os: getPlatform(),
+      nodeVersion: process.version,
+      version,
+      command,
+      authType,
+      step,
+    });
+  } catch (e) {
+    logger.debug('Auth action tracking failed: %s', e.message);
+  }
 };
 
 module.exports = {
   trackCommandUsage,
   trackHelpUsage,
   addHelpUsageTracking,
-  trackCommandAction,
+  trackAuthAction,
 };

--- a/packages/cms-cli/lib/usageTracking.js
+++ b/packages/cms-cli/lib/usageTracking.js
@@ -1,8 +1,6 @@
 const { trackUsage } = require('@hubspot/cms-lib/api/fileMapper');
-const {
-  getAndLoadConfigIfNeeded,
-  getPortalConfig,
-} = require('@hubspot/cms-lib');
+const { getPortalConfig } = require('@hubspot/cms-lib');
+const { isTrackingAllowed } = require('@hubspot/cms-lib/lib/config');
 const { logger } = require('@hubspot/cms-lib/logger');
 const { version } = require('../package.json');
 const { getPlatform } = require('./environment');
@@ -14,11 +12,6 @@ const EventClass = {
   VIEW: 'VIEW',
   ACTIVATION: 'ACTIVATION',
 };
-
-function isTrackingAllowed() {
-  const { allowUsageTracking } = getAndLoadConfigIfNeeded();
-  return allowUsageTracking !== false;
-}
 
 function trackCommandUsage(command, meta = {}, portalId) {
   if (!isTrackingAllowed()) {

--- a/packages/cms-cli/lib/usageTracking.js
+++ b/packages/cms-cli/lib/usageTracking.js
@@ -75,8 +75,13 @@ const addHelpUsageTracking = (program, command) => {
   });
 };
 
+const trackCommandAction = (command, action, ...rest) => {
+  return trackCommandUsage(`${command}: ${action}`, ...rest);
+};
+
 module.exports = {
   trackCommandUsage,
   trackHelpUsage,
   addHelpUsageTracking,
+  trackCommandAction,
 };

--- a/packages/cms-lib/lib/__mocks__/fs.js
+++ b/packages/cms-lib/lib/__mocks__/fs.js
@@ -1,0 +1,14 @@
+const fs = jest.genMockFromModule('fs');
+
+let mockedReadFile = '';
+let mockedExistsValue = false;
+
+fs.__setReadFile = newValue => (mockedReadFile = newValue);
+fs.__setExistsValue = newValue => (mockedExistsValue = newValue);
+
+fs.readFileSync = () => mockedReadFile;
+fs.existsSync = () => mockedExistsValue;
+fs.writeFileSync = () => true;
+fs.unlinkSync = () => true;
+
+module.exports = fs;

--- a/packages/cms-lib/lib/config.js
+++ b/packages/cms-lib/lib/config.js
@@ -56,12 +56,14 @@ const parseConfig = configSource => {
   return { parsed, error };
 };
 
-const loadConfig = path => {
+const loadConfig = (path, options = {}) => {
   _configPath = getConfigPath(path);
   if (!_configPath) {
-    logger.error(
-      `A ${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME} file could not be found`
-    );
+    if (!options.silenceErrors) {
+      logger.error(
+        `A ${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME} file could not be found`
+      );
+    }
     return;
   }
 
@@ -81,9 +83,19 @@ const loadConfig = path => {
   }
 };
 
+const isTrackingAllowed = () => {
+  if (!configFileExists() || configFileIsBlank()) {
+    return true;
+  }
+  const { allowUsageTracking } = getAndLoadConfigIfNeeded();
+  return allowUsageTracking !== false;
+};
+
 const getAndLoadConfigIfNeeded = () => {
   if (!_config) {
-    loadConfig();
+    loadConfig(null, {
+      silenceErrors: true,
+    });
   }
   return _config;
 };
@@ -277,4 +289,5 @@ module.exports = {
   updateDefaultPortal,
   createEmptyConfigFile,
   deleteEmptyConfigFile,
+  isTrackingAllowed,
 };

--- a/packages/cms-lib/lib/config.js
+++ b/packages/cms-lib/lib/config.js
@@ -264,6 +264,10 @@ const configFileIsBlank = () => {
 const createEmptyConfigFile = ({ deleteOnExitIfBlank }) => {
   setDefaultConfigPathIfUnset();
 
+  if (configFileExists()) {
+    return;
+  }
+
   if (deleteOnExitIfBlank) {
     process.on('exit', deleteEmptyConfigFile);
   }

--- a/packages/cms-lib/lib/config.js
+++ b/packages/cms-lib/lib/config.js
@@ -227,7 +227,14 @@ const updateDefaultPortal = defaultPortal => {
 
   const config = getAndLoadConfigIfNeeded();
   config.defaultPortal = defaultPortal;
+  setDefaultConfigPathIfUnset();
   writeConfig();
+};
+
+const setDefaultConfigPathIfUnset = () => {
+  if (!_configPath) {
+    setDefaultConfigPath();
+  }
 };
 
 const setDefaultConfigPath = () => {
@@ -243,9 +250,7 @@ const configFileIsBlank = () => {
 };
 
 const createEmptyConfigFile = () => {
-  if (!_configPath) {
-    setDefaultConfigPath();
-  }
+  setDefaultConfigPathIfUnset();
 
   return fs.writeFileSync(_configPath, EMPTY_CONFIG_FILE_CONTENTS);
 };

--- a/packages/cms-lib/lib/config.js
+++ b/packages/cms-lib/lib/config.js
@@ -261,15 +261,11 @@ const configFileIsBlank = () => {
   return _configPath && fs.readFileSync(_configPath).length === 0;
 };
 
-const createEmptyConfigFile = ({ deleteOnExitIfBlank }) => {
+const createEmptyConfigFile = () => {
   setDefaultConfigPathIfUnset();
 
   if (configFileExists()) {
     return;
-  }
-
-  if (deleteOnExitIfBlank) {
-    process.on('exit', deleteEmptyConfigFile);
   }
 
   return fs.writeFileSync(_configPath, EMPTY_CONFIG_FILE_CONTENTS);

--- a/packages/cms-lib/lib/config.js
+++ b/packages/cms-lib/lib/config.js
@@ -249,8 +249,12 @@ const configFileIsBlank = () => {
   return _configPath && fs.readFileSync(_configPath).length === 0;
 };
 
-const createEmptyConfigFile = () => {
+const createEmptyConfigFile = ({ deleteOnExitIfBlank }) => {
   setDefaultConfigPathIfUnset();
+
+  if (deleteOnExitIfBlank) {
+    process.on('exit', deleteEmptyConfigFile);
+  }
 
   return fs.writeFileSync(_configPath, EMPTY_CONFIG_FILE_CONTENTS);
 };

--- a/packages/cms-lib/lib/constants.js
+++ b/packages/cms-lib/lib/constants.js
@@ -45,6 +45,8 @@ const AUTH_METHODS = {
   },
 };
 
+const DEFAULT_OAUTH_SCOPES = ['content'];
+
 module.exports = {
   Mode,
   ALLOWED_EXTENSIONS,
@@ -54,4 +56,5 @@ module.exports = {
   DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
   EMPTY_CONFIG_FILE_CONTENTS,
   AUTH_METHODS,
+  DEFAULT_OAUTH_SCOPES,
 };

--- a/packages/cms-lib/oauth.js
+++ b/packages/cms-lib/oauth.js
@@ -1,7 +1,7 @@
 const OAuth2Manager = require('@hubspot/api-auth-lib/OAuth2Manager');
 const { updatePortalConfig, getPortalConfig } = require('./lib/config');
 const { logger, logErrorInstance } = require('./logger');
-const { AUTH_METHODS } = require('./lib/constants');
+const { AUTH_METHODS, DEFAULT_OAUTH_SCOPES } = require('./lib/constants');
 
 const oauthManagers = new Map();
 
@@ -52,14 +52,23 @@ const addOauthToPortalConfig = (portalId, oauth) => {
       portalId,
     });
     logger.log('Configuration updated');
-    process.exit();
   } catch (err) {
     logErrorInstance(err);
   }
 };
 
+const authenticateWithOauth = async configData => {
+  const portalId = parseInt(configData.portalId, 10);
+  const oauth = setupOauth(portalId, {
+    scopes: DEFAULT_OAUTH_SCOPES,
+    ...configData,
+  });
+  logger.log('Authorizing');
+  await oauth.authorize();
+  addOauthToPortalConfig(portalId, oauth);
+};
+
 module.exports = {
   getOauthManager,
-  setupOauth,
-  addOauthToPortalConfig,
+  authenticateWithOauth,
 };


### PR DESCRIPTION
Gregory noticed that a test was failing, which should have been removed with the previous PR. This PR removes that test and adds some additional tests as well as fixes a small bug that I discovered while adding tests.

I merged the documentation update into this PR as well, which will allow help text to show up for the `hs init` command and adds updated instructions to the README.md.

This PR also has added tracking for `hs init` for status: 'started' and status: 'complete' so we can monitor the usage of the OAuth2 and API Key flows independently to see their completion rates.