### PR TITLE
Add new filemanager subcommand for uploading files to the File Manager

### DIFF
--- a/packages/cms-cli/README.md
+++ b/packages/cms-cli/README.md
@@ -61,13 +61,13 @@ Show all commands
 hs help
 ```
 
-Upload a file or directory to HubSpot
+Upload a file or directory to the Design Manager
 
 ```bash
 hs upload --portal=DEV [src] [dest]
 ```
 
-Fetch a file or directory by path
+Fetch a file or directory by path from the Design Manager
 
 ```bash
 hs fetch --portal=DEV [path] [dest]
@@ -76,19 +76,19 @@ hs fetch --portal=DEV [path] [dest]
 hs fetch --portal=DEV --overwrite [path] [dest]
 ```
 
-Watch a directory of files and automatically upload changes
+Watch a directory of files and automatically upload changes to the Design Manager
 
 ```bash
 hs watch --portal=DEV [src] [dest]
 ```
 
-Create a new asset
+Create a new asset locally
 
 ```bash
 hs create [type] [dest]
 ```
 
-Delete a file or directory from HubSpot
+Delete a file or directory from the Design Manager
 
 ```bash
 hs remove --portal=DEV [path]
@@ -99,3 +99,11 @@ Authenticate against a portal using OAuth2
 ```bash
 hs auth oauth2
 ```
+
+Upload a file or directory to the File Manager
+
+```bash
+hs filemanager upload --portal=DEV [src] [dest]
+```
+
+**Note:** Uploading to the File Manager is only supported when using the `apiKey` at this point.

--- a/packages/cms-cli/bin/hs-filemanager-upload.js
+++ b/packages/cms-cli/bin/hs-filemanager-upload.js
@@ -1,0 +1,11 @@
+#!/usr/bin/en node
+
+const { Command } = require('commander');
+
+const {
+  configureFileManagerUploadCommand,
+} = require('../commands/filemanager');
+
+const program = new Command('hs filemanager upload');
+configureFileManagerUploadCommand(program);
+program.parse(process.argv);

--- a/packages/cms-cli/bin/hs-filemanager.js
+++ b/packages/cms-cli/bin/hs-filemanager.js
@@ -1,0 +1,9 @@
+#!/usr/bin/en node
+
+const { Command } = require('commander');
+
+const { configureFileManagerCommand } = require('../commands/filemanager');
+
+const program = new Command('hscms filemanager');
+configureFileManagerCommand(program);
+program.parse(process.argv);

--- a/packages/cms-cli/bin/hscms-filemanager-upload.js
+++ b/packages/cms-cli/bin/hscms-filemanager-upload.js
@@ -1,0 +1,11 @@
+#!/usr/bin/en node
+
+const { Command } = require('commander');
+
+const {
+  configureFileManagerUploadCommand,
+} = require('../commands/filemanager');
+
+const program = new Command('hscms filemanager upload');
+configureFileManagerUploadCommand(program);
+program.parse(process.argv);

--- a/packages/cms-cli/bin/hscms-filemanager.js
+++ b/packages/cms-cli/bin/hscms-filemanager.js
@@ -1,0 +1,9 @@
+#!/usr/bin/en node
+
+const { Command } = require('commander');
+
+const { configureFileManagerCommand } = require('../commands/filemanager');
+
+const program = new Command('hs filemanager');
+configureFileManagerCommand(program);
+program.parse(process.argv);

--- a/packages/cms-cli/commands/filemanager.js
+++ b/packages/cms-cli/commands/filemanager.js
@@ -1,0 +1,151 @@
+const fs = require('fs');
+const path = require('path');
+const { version } = require('../package.json');
+
+const { loadConfig } = require('@hubspot/cms-lib');
+const { uploadFolder } = require('@hubspot/cms-lib/fileManager');
+const { uploadFile } = require('@hubspot/cms-lib/api/fileManager');
+const { getCwd, convertToUnixPath } = require('@hubspot/cms-lib/path');
+const { logger } = require('@hubspot/cms-lib/logger');
+const {
+  logErrorInstance,
+  ApiErrorContext,
+  logApiUploadErrorInstance,
+} = require('@hubspot/cms-lib/errorHandlers');
+const { validateSrcAndDestPaths } = require('@hubspot/cms-lib/modules');
+const { shouldIgnoreFile } = require('@hubspot/cms-lib/ignoreRules');
+
+const {
+  addConfigOptions,
+  addPortalOptions,
+  addLoggerOptions,
+  setLogLevel,
+  getPortalId,
+} = require('../lib/commonOpts');
+const { logDebugInfo } = require('../lib/debugInfo');
+const { validateConfig, validatePortal } = require('../lib/validation');
+const {
+  trackCommandUsage,
+  addHelpUsageTracking,
+} = require('../lib/usageTracking');
+
+const COMMAND_NAME = 'upload';
+
+function configureFileManagerCommand(program) {
+  program
+    .version(version)
+    .description('Commands for working with the File Manager')
+    .command('upload <src> <dest>', 'upload files to the file manager');
+
+  addLoggerOptions(program);
+  addHelpUsageTracking(program);
+}
+
+function configureFileManagerUploadCommand(program) {
+  program
+    .version(version)
+    .description(
+      'Upload a folder or file from your computer to the HubSpot File Manager'
+    )
+    .arguments('<src> <dest>')
+    .action(async (src, dest, command = {}) => {
+      setLogLevel(command);
+      logDebugInfo(command);
+      const { config: configPath } = command;
+      loadConfig(configPath);
+
+      if (!validateConfig() || !(await validatePortal(command))) {
+        process.exit(1);
+      }
+
+      const portalId = getPortalId(command);
+      const absoluteSrcPath = path.resolve(getCwd(), src);
+
+      let stats;
+      try {
+        stats = fs.statSync(absoluteSrcPath);
+        if (!stats.isFile() && !stats.isDirectory()) {
+          logger.error(`The path "${src}" is not a path to a file or folder`);
+          return;
+        }
+      } catch (e) {
+        logger.error(`The path "${src}" is not a path to a file or folder`);
+        return;
+      }
+
+      if (!dest) {
+        logger.error('A destination path needs to be passed');
+        return;
+      }
+      const normalizedDest = convertToUnixPath(dest);
+      trackCommandUsage(
+        COMMAND_NAME,
+        { type: stats.isFile() ? 'file' : 'folder' },
+        portalId
+      );
+
+      const srcDestIssues = await validateSrcAndDestPaths(
+        { isLocal: true, path: src },
+        { isHubSpot: true, path: dest }
+      );
+      if (srcDestIssues.length) {
+        srcDestIssues.forEach(({ message }) => logger.error(message));
+        process.exit(1);
+      }
+
+      if (stats.isFile()) {
+        if (shouldIgnoreFile(absoluteSrcPath, getCwd())) {
+          logger.error(
+            `The file "${src}" is being ignored via an .hsignore rule`
+          );
+          return;
+        }
+
+        uploadFile(portalId, absoluteSrcPath, normalizedDest)
+          .then(() => {
+            logger.log('Uploaded file "%s" to "%s"', src, normalizedDest);
+          })
+          .catch(error => {
+            logger.error(
+              'Uploading file "%s" to "%s" failed',
+              src,
+              normalizedDest
+            );
+            logApiUploadErrorInstance(
+              error,
+              new ApiErrorContext({
+                portalId,
+                request: normalizedDest,
+                payload: src,
+              })
+            );
+          });
+      } else {
+        logger.log(
+          `Uploading files from ${src} to ${dest} in portal ${portalId}`
+        );
+        uploadFolder(portalId, absoluteSrcPath, dest, {
+          cwd: getCwd(),
+        })
+          .then(() => {
+            logger.log(`Uploading files to ${dest} is complete`);
+          })
+          .catch(error => {
+            logger.error('Uploading failed');
+            logErrorInstance(error, {
+              portalId,
+            });
+          });
+      }
+    });
+
+  addConfigOptions(program);
+  addPortalOptions(program);
+  addLoggerOptions(program);
+  addHelpUsageTracking(program, COMMAND_NAME);
+}
+
+module.exports = {
+  configureFileManagerUploadCommand,
+  configureFileManagerCommand,
+};

--- a/packages/cms-cli/commands/filemanager.js
+++ b/packages/cms-cli/commands/filemanager.js
@@ -29,7 +29,7 @@ const {
   addHelpUsageTracking,
 } = require('../lib/usageTracking');
 
-const COMMAND_NAME = 'upload';
+const COMMAND_NAME = 'filemanager-upload';
 
 function configureFileManagerCommand(program) {
   program

--- a/packages/cms-cli/commands/main.js
+++ b/packages/cms-cli/commands/main.js
@@ -24,6 +24,10 @@ function configureMainCommand(program) {
     .command('hubdb <subcommand> <src>', 'manage hubdb tables', {
       noHelp: true,
     })
+    .command(
+      'filemanager <subcommand>',
+      'commands for working with the File Manager'
+    )
     .command('remove <path>', 'delete a file or folder from HubSpot')
     .alias('rm');
 

--- a/packages/cms-lib/api/fileManager.js
+++ b/packages/cms-lib/api/fileManager.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+const http = require('../http');
+
+const FILE_MANAGER_API_PATH = 'filemanager/api/v2';
+
+async function uploadFile(portalId, src, dest) {
+  const directory = path.dirname(dest);
+  const filename = path.basename(dest);
+
+  return http.post(portalId, {
+    uri: `${FILE_MANAGER_API_PATH}/files`,
+    qs: {
+      overwrite: 'true',
+    },
+    formData: {
+      file: fs.createReadStream(src),
+      file_names: filename,
+      folder_paths: directory,
+    },
+  });
+}
+
+module.exports = {
+  uploadFile,
+};

--- a/packages/cms-lib/fileManager.js
+++ b/packages/cms-lib/fileManager.js
@@ -1,0 +1,63 @@
+const path = require('path');
+const { default: PQueue } = require('p-queue');
+
+const { uploadFile } = require('./api/fileManager');
+const { walk } = require('./lib/walk');
+const { logger } = require('./logger');
+const { createIgnoreFilter } = require('./ignoreRules');
+const escapeRegExp = require('./lib/escapeRegExp');
+const { convertToUnixPath } = require('./path');
+const {
+  ApiErrorContext,
+  logApiUploadErrorInstance,
+  isFatalError,
+} = require('./errorHandlers');
+
+const queue = new PQueue({
+  concurrency: 10,
+});
+
+/**
+ *
+ * @param {number} portalId
+ * @param {string} src
+ * @param {string} dest
+ * @param {object} options
+ */
+async function uploadFolder(portalId, src, dest, { cwd }) {
+  const regex = new RegExp(`^${escapeRegExp(src)}`);
+  const files = await walk(src);
+
+  const filesToUpload = files.filter(createIgnoreFilter(cwd));
+
+  return queue.addAll(
+    filesToUpload.map(file => {
+      const relativePath = file.replace(regex, '');
+      const destPath = convertToUnixPath(path.join(dest, relativePath));
+      return async () => {
+        logger.debug('Attempting to upload file "%s" to "%s"', file, destPath);
+        try {
+          await uploadFile(portalId, file, destPath);
+          logger.log('Uploaded file "%s" to "%s"', file, destPath);
+        } catch (error) {
+          logger.error('Uploading file "%s" to "%s" failed', file, destPath);
+          if (isFatalError(error)) {
+            throw error;
+          }
+          logApiUploadErrorInstance(
+            error,
+            new ApiErrorContext({
+              portalId,
+              request: destPath,
+              payload: file,
+            })
+          );
+        }
+      };
+    })
+  );
+}
+
+module.exports = {
+  uploadFolder,
+};


### PR DESCRIPTION
This PR adds a new `filemanager` subcommand for uploading files to the File Manager.

Part of #13 

- [x] Update documentation