### PR TITLE
Fix refreshing authorization token when portal is named in config

### DIFF
--- a/packages/cms-lib/oauth.js
+++ b/packages/cms-lib/oauth.js
@@ -6,12 +6,13 @@ const { AUTH_METHODS, DEFAULT_OAUTH_SCOPES } = require('./lib/constants');
 const oauthManagers = new Map();
 
 const writeOauthTokenInfo = (portalConfig, tokenInfo) => {
-  const { portalId, authType, auth, env, name } = portalConfig;
+  const { portalId, authType, auth, env, name, apiKey } = portalConfig;
 
   logger.debug(`Updating Oauth2 token info for portalId: ${portalId}`);
 
   updatePortalConfig({
     name,
+    apiKey,
     environment: env,
     portalId,
     authType,

--- a/packages/cms-lib/oauth.js
+++ b/packages/cms-lib/oauth.js
@@ -6,11 +6,12 @@ const { AUTH_METHODS, DEFAULT_OAUTH_SCOPES } = require('./lib/constants');
 const oauthManagers = new Map();
 
 const writeOauthTokenInfo = (portalConfig, tokenInfo) => {
-  const { portalId, authType, auth, env } = portalConfig;
+  const { portalId, authType, auth, env, name } = portalConfig;
 
   logger.debug(`Updating Oauth2 token info for portalId: ${portalId}`);
 
   updatePortalConfig({
+    name,
     environment: env,
     portalId,
     authType,


### PR DESCRIPTION
This was introduced via https://github.com/HubSpot/hubspot-cms-tools/pull/19/files#diff-559c11df4e260265a029eeeef8fa4bd9R191 and the way we're using the spread operator.