### PR TITLE
Use shouldIgnoreFunction in chokidar ignored attribute to reduce watches

### DIFF
--- a/packages/cms-lib/lib/watch.js
+++ b/packages/cms-lib/lib/watch.js
@@ -54,6 +54,7 @@ function watch(portalId, src, dest, { mode, cwd, remove }) {
 
   const watcher = chokidar.watch(src, {
     ignoreInitial: true,
+    ignored: (file) => shouldIgnoreFile(file, cwd),
   });
 
   const getDesignManagerPath = file => {


### PR DESCRIPTION
Have done some basic testing, haven't updated unit tests though.

Reduces memory usage and CPU a fair bit on my mac - I'm guessing that's because beforehand it was watching node_modules and all the files listed in .hsignore.

I imagine converting the ignore list (from .hsignore) to an array and passing it into ignored in chokidar would be faster/less fn calls, but I'm not sure of the compatibility of the ignore format -> anymatch. 
