### PR TITLE
Updates to walk and watch to fix issues with symlinks and hidden files

### DIFF
--- a/packages/cms-lib/__tests__/ignoreRules.js
+++ b/packages/cms-lib/__tests__/ignoreRules.js
@@ -1,0 +1,35 @@
+const { shouldIgnoreFile } = require('../ignoreRules');
+
+const CWD = '/Path/To/My/Repo';
+const REPO_FOLDER = `${CWD}/repo-name-here`;
+const NODE_MODULES_FOLDER = `${REPO_FOLDER}/node_modules`;
+const NODE_MODULES_FILE = `${NODE_MODULES_FOLDER}/a-really-fake-package-name/README.md`;
+
+describe('ignoreRules', () => {
+  describe('shouldIgnoreFile', () => {
+    it('ignores node_modules folder', () => {
+      expect(shouldIgnoreFile(NODE_MODULES_FOLDER, CWD)).toBe(true);
+    });
+
+    it('ignores files nested within node_modules folder', () => {
+      expect(shouldIgnoreFile(NODE_MODULES_FILE, CWD)).toBe(true);
+    });
+
+    it('ignores hidden folders', () => {
+      expect(shouldIgnoreFile(`${REPO_FOLDER}/.hiddenFolder`, CWD)).toBe(true);
+    });
+
+    it('ignores hidden files', () => {
+      expect(shouldIgnoreFile(`${REPO_FOLDER}/.hiddenFile.js`, CWD)).toBe(true);
+      expect(shouldIgnoreFile(`${REPO_FOLDER}/.*`, CWD)).toBe(true);
+    });
+
+    it('does not ignore allowed folders', () => {
+      expect(shouldIgnoreFile(`${REPO_FOLDER}/hiddenFile/`, CWD)).toBe(false);
+    });
+
+    it('does not ignore allowed files', () => {
+      expect(shouldIgnoreFile(`${REPO_FOLDER}/hiddenFile.js`, CWD)).toBe(false);
+    });
+  });
+});

--- a/packages/cms-lib/ignoreRules.js
+++ b/packages/cms-lib/ignoreRules.js
@@ -8,7 +8,7 @@ const findup = require('findup-sync');
 const ignoreList = [
   '**/node_modules', // dependencies
   '**/.*', // hidden files/folders
-  '**/npm-debug.log', // Error log for npm
+  '**/*.log', // Error log for npm
   '**/*.swp', // Swap file for vim state
 
   // # macOS

--- a/packages/cms-lib/ignoreRules.js
+++ b/packages/cms-lib/ignoreRules.js
@@ -3,7 +3,10 @@ const path = require('path');
 const ignore = require('ignore');
 const findup = require('findup-sync');
 
-const ignoreRules = ignore().add('node_modules');
+const hiddenFilesRegEx = /(^|\/)\.[^/.]/g;
+const ignoreRules = ignore()
+  .add('node_modules')
+  .add(hiddenFilesRegEx);
 
 let configPath = null;
 let loaded = false;

--- a/packages/cms-lib/ignoreRules.js
+++ b/packages/cms-lib/ignoreRules.js
@@ -3,10 +3,10 @@ const path = require('path');
 const ignore = require('ignore');
 const findup = require('findup-sync');
 
-const hiddenFilesRegEx = /(^|\/)\.[^/.]/g;
-const ignoreRules = ignore()
-  .add('node_modules')
-  .add(hiddenFilesRegEx);
+const ignoreRules = ignore().add([
+  'node_modules', // dependencies
+  '.*', // hidden files/folders
+]);
 
 let configPath = null;
 let loaded = false;

--- a/packages/cms-lib/ignoreRules.js
+++ b/packages/cms-lib/ignoreRules.js
@@ -3,10 +3,29 @@ const path = require('path');
 const ignore = require('ignore');
 const findup = require('findup-sync');
 
-const ignoreRules = ignore().add([
-  'node_modules', // dependencies
-  '.*', // hidden files/folders
-]);
+// Rules used by ignore do not allow RegEx -- we are basing most of this list
+// on the Junk library, which uses RegEx https://github.com/sindresorhus/junk/blob/master/index.js#L3
+const ignoreList = [
+  '**/node_modules', // dependencies
+  '**/.*', // hidden files/folders
+  '**/npm-debug.log', // Error log for npm
+  '**/*.swp', // Swap file for vim state
+
+  // # macOS
+  '**/Icon\\r', // Custom Finder icon: http://superuser.com/questions/298785/icon-file-on-os-x-desktop
+  '**/__MACOSX', // Resource fork
+
+  // # Linux
+  '**/~', // Backup file
+
+  // # Windows
+  '**/Thumbs.db', // Image file cache
+  '**/ehthumbs.db', // Folder config file
+  '**/Desktop.ini', // Stores custom folder attributes
+  '**/@eaDir', // Synology Diskstation "hidden" folder where the server stores thumbnails
+];
+
+const ignoreRules = ignore().add(ignoreList);
 
 let configPath = null;
 let loaded = false;

--- a/packages/cms-lib/lib/walk.js
+++ b/packages/cms-lib/lib/walk.js
@@ -1,7 +1,5 @@
 const fs = require('fs');
 const path = require('path');
-const { logger } = require('../logger');
-const { logFileSystemErrorInstance } = require('../errorHandlers');
 
 const STAT_TYPES = {
   FILE: 'file',
@@ -23,11 +21,11 @@ const generateFilePromise = (dir, file) => {
         });
       }
       if (stats.isDirectory()) {
-        walk(filepath).then(fileContents => {
+        walk(filepath).then(files => {
           return resolve({
             filepath,
             type: STAT_TYPES.DIRECTORY,
-            fileContents,
+            files,
           });
         });
       } else if (stats.isFile()) {
@@ -37,24 +35,20 @@ const generateFilePromise = (dir, file) => {
         });
       }
     });
-  }).catch(logger.error);
+  });
 };
 
-const filesDataReducer = (all, fileData) => {
-  try {
-    switch (fileData.type) {
-      case STAT_TYPES.FILE:
-        return all.concat(fileData.filepath);
-      case STAT_TYPES.DIRECTORY:
-        return all.concat(fileData.fileContents);
-      case STAT_TYPES.SYMBOLIC_LINK:
-        // Skip symlinks
-        return all;
-      default:
-        return all;
-    }
-  } catch (e) {
-    logFileSystemErrorInstance(e, fileData);
+const filesDataReducer = (allFiles, fileData) => {
+  switch (fileData.type) {
+    case STAT_TYPES.FILE:
+      return allFiles.concat(fileData.filepath);
+    case STAT_TYPES.DIRECTORY:
+      return allFiles.concat(fileData.fileContents);
+    case STAT_TYPES.SYMBOLIC_LINK:
+      // Skip symlinks
+      return allFiles;
+    default:
+      return allFiles;
   }
 };
 

--- a/packages/cms-lib/lib/walk.js
+++ b/packages/cms-lib/lib/walk.js
@@ -26,7 +26,8 @@ function walk(dir) {
       if (error) {
         reject(error);
       }
-      processFiles(files).then(foldersContents => {
+      const displayedFiles = files.filter(item => !/(^|\/)\.[^/.]/g.test(item));
+      processFiles(displayedFiles).then(foldersContents => {
         resolve(
           foldersContents.reduce(
             (all, folderContents) => all.concat(folderContents),

--- a/packages/cms-lib/lib/walk.js
+++ b/packages/cms-lib/lib/walk.js
@@ -1,47 +1,74 @@
 const fs = require('fs');
 const path = require('path');
 const { logger } = require('../logger');
+const { logFileSystemErrorInstance } = require('../errorHandlers');
+
+const STAT_TYPES = {
+  FILE: 'file',
+  SYMBOLIC_LINK: 'symlink',
+  DIRECTORY: 'dir',
+};
+
+const generateFilePromise = (dir, file) => {
+  return new Promise((resolve, reject) => {
+    const filepath = path.join(dir, file);
+    fs.lstat(filepath, (error, stats) => {
+      if (error) {
+        reject(error);
+      }
+      if (stats.isSymbolicLink()) {
+        resolve({
+          filepath,
+          type: STAT_TYPES.SYMBOLIC_LINK,
+        });
+      }
+      if (stats.isDirectory()) {
+        walk(filepath).then(fileContents => {
+          return resolve({
+            filepath,
+            type: STAT_TYPES.DIRECTORY,
+            fileContents,
+          });
+        });
+      } else if (stats.isFile()) {
+        resolve({
+          filepath,
+          type: STAT_TYPES.FILE,
+        });
+      }
+    });
+  }).catch(logger.error);
+};
+
+const filesDataReducer = (all, fileData) => {
+  try {
+    switch (fileData.type) {
+      case STAT_TYPES.FILE:
+        return all.concat(fileData.filepath);
+      case STAT_TYPES.DIRECTORY:
+        return all.concat(fileData.fileContents);
+      case STAT_TYPES.SYMBOLIC_LINK:
+        // Skip symlinks
+        return all;
+      default:
+        return all;
+    }
+  } catch (e) {
+    logFileSystemErrorInstance(e, fileData);
+  }
+};
 
 function walk(dir) {
   const processFiles = files => {
-    return Promise.all(
-      files.map(file => {
-        return new Promise((resolve, reject) => {
-          const filepath = path.join(dir, file);
-          fs.lstat(filepath, (error, stats) => {
-            if (error) {
-              reject(error);
-            }
-            if (stats.isSymbolicLink()) {
-              logger.debug(`Skipping Symlink in walk: ${filepath}`);
-              reject(error);
-            }
-            if (stats.isDirectory()) {
-              walk(filepath).then(resolve);
-            } else if (stats.isFile()) {
-              resolve(filepath);
-            }
-          });
-        }).catch(error => {
-          if (error) {
-            logger.error(error);
-          }
-        });
-      })
-    );
+    return Promise.all(files.map(file => generateFilePromise(dir, file)));
   };
   return new Promise((resolve, reject) => {
     fs.readdir(dir, (error, files) => {
       if (error) {
         reject(error);
       }
-      processFiles(files).then(foldersContents => {
-        resolve(
-          foldersContents.reduce(
-            (all, folderContents) => all.concat(folderContents),
-            []
-          )
-        );
+      processFiles(files).then(filesData => {
+        resolve(filesData.reduce(filesDataReducer, []));
       });
     });
   });

--- a/packages/cms-lib/lib/walk.js
+++ b/packages/cms-lib/lib/walk.js
@@ -7,9 +7,12 @@ function walk(dir) {
       files.map(file => {
         return new Promise((resolve, reject) => {
           const filepath = path.join(dir, file);
-          fs.stat(filepath, (error, stats) => {
+          fs.lstat(filepath, (error, stats) => {
             if (error) {
               reject(error);
+            }
+            if (stats.isSymbolicLink()) {
+              resolve(filepath);
             }
             if (stats.isDirectory()) {
               walk(filepath).then(resolve);
@@ -26,8 +29,7 @@ function walk(dir) {
       if (error) {
         reject(error);
       }
-      const displayedFiles = files.filter(item => !/(^|\/)\.[^/.]/g.test(item));
-      processFiles(displayedFiles).then(foldersContents => {
+      processFiles(files).then(foldersContents => {
         resolve(
           foldersContents.reduce(
             (all, folderContents) => all.concat(folderContents),

--- a/packages/cms-lib/lib/walk.js
+++ b/packages/cms-lib/lib/walk.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { logger } = require('../logger');
 
 function walk(dir) {
   const processFiles = files => {
@@ -12,7 +13,8 @@ function walk(dir) {
               reject(error);
             }
             if (stats.isSymbolicLink()) {
-              resolve(filepath);
+              logger.debug(`Skipping Symlink in walk: ${filepath}`);
+              reject(error);
             }
             if (stats.isDirectory()) {
               walk(filepath).then(resolve);
@@ -20,6 +22,10 @@ function walk(dir) {
               resolve(filepath);
             }
           });
+        }).catch(error => {
+          if (error) {
+            logger.error(error);
+          }
         });
       })
     );


### PR DESCRIPTION
Fixes #39 
Fixes #40 

### What this PR does
- Skips symlinks when running walk on a dir
- Updates watch task so it ignores hidden files/folders
- Adds tests for ignoreRules
- Adds more rules to ignoreRules based on those in junk library(https://github.com/sindresorhus/junk/blob/master/index.js#L3)