### PR TITLE
Improve watch command

### DIFF
--- a/packages/cms-cli/commands/watch.js
+++ b/packages/cms-cli/commands/watch.js
@@ -36,10 +36,11 @@ function configureWatchCommand(program) {
     )
     .arguments('<src> <dest>')
     .option('--remove', 'remove remote files when removed locally')
+    .option('--disable-initial', 'disable initial upload of watched directory')
     .action(async (src, dest, command = {}) => {
       setLogLevel(command);
       logDebugInfo(command);
-      const { config: configPath, remove } = command;
+      const { config: configPath, remove, disableInitial } = command;
       loadConfig(configPath);
 
       if (
@@ -77,6 +78,7 @@ function configureWatchCommand(program) {
         mode,
         cwd: getCwd(),
         remove,
+        disableInitial,
       });
     });
 

--- a/packages/cms-lib/lib/watch.js
+++ b/packages/cms-lib/lib/watch.js
@@ -49,7 +49,7 @@ function uploadFile(portalId, file, dest, { mode, cwd }) {
     });
 }
 
-function watch(portalId, src, dest, { mode, cwd, remove }) {
+function watch(portalId, src, dest, { mode, cwd, remove, disableInitial }) {
   const regex = new RegExp(`^${escapeRegExp(src)}`);
 
   const watcher = chokidar.watch(src, {
@@ -62,13 +62,15 @@ function watch(portalId, src, dest, { mode, cwd, remove }) {
     return convertToUnixPath(path.join(dest, relativePath));
   };
 
-  // Use uploadFolder so that failures of initial upload are retried
-  uploadFolder(portalId, src, dest, { mode, cwd }).then(() => {
-    logger.log(`Completed uploading files in ${src} to ${dest} in ${portalId}`);
-  });
+  if (!disableInitial) {
+    // Use uploadFolder so that failures of initial upload are retried
+    uploadFolder(portalId, src, dest, { mode, cwd }).then(() => {
+      logger.log(`Completed uploading files in ${src} to ${dest} in ${portalId}`);
+    });
+  }
 
   watcher.on('ready', () => {
-    logger.debug(`File watcher is ready and watching ${src}`);
+    logger.log(`Watcher is ready and watching ${src}`);
   });
 
   watcher.on('add', file => {


### PR DESCRIPTION
This PR includes the following improvements to the watch command
- Add queue to reduce concurrent uploads when lots of files are touched
- Add `--disable-initial` option to disable initial upload when watching a directory

Fixes #29