### PR TITLE
Success message for createProject

### DIFF
--- a/packages/create-cms-project/lib/createProject.js
+++ b/packages/create-cms-project/lib/createProject.js
@@ -72,6 +72,7 @@ async function createProject(projectName, options) {
   fs.ensureDirSync(dest);
   await cloneBoilerplate(dest, options);
   await installDeps(dest, options);
+  console.log(`Success: your new project has been created in ${dest}.`);
 }
 
 exports = module.exports = createProject;

--- a/packages/create-cms-project/lib/createProject.js
+++ b/packages/create-cms-project/lib/createProject.js
@@ -72,7 +72,9 @@ async function createProject(projectName, options) {
   fs.ensureDirSync(dest);
   await cloneBoilerplate(dest, options);
   await installDeps(dest, options);
-  console.log(`Success: your new project has been created in ${dest}.`);
+  console.log(
+    `Success: your new ${options.repo} project has been created in ${dest}.`
+  );
 }
 
 exports = module.exports = createProject;


### PR DESCRIPTION
Fixes #44 
### What this PR does
Adds a success message when creating a new project using the `create-cms-project` command.

> Success: your new HubSpot/cms-theme-boilerplate project has been created in /Users/mtalley/HubSpot/Prod/hubspot-cms-tools/test.