### PR TITLE
Fixed publish-release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "lint": "eslint . && prettier --list-different 'packages/**/*.{js,json}'",
     "prettier:write": "prettier --write 'packages/**/*.{js,json}'",
-    "publish-release": "yarn lerna publish --conventional-graduate",
+    "publish-release": "yarn lerna publish --conventional-commits --conventional-graduate",
     "publish-prerelease": "yarn lerna publish prerelease --preid beta --dist-tag next",
     "test": "jest"
   },


### PR DESCRIPTION
When trying to promote the prerelease today `yarn publish-release` did not detect any changes to publish. It looks like we are running into [this issue](https://github.com/lerna/lerna/issues/2143). When running `yarn lerna publish --conventional-commits --conventional-graduate` lerna was able to detect and publish the changes.