### PR TITLE
Decrease likelihood of dependencies being uploaded after dependents

### DIFF
--- a/packages/cms-lib/lib/__tests__/uploadFolder.js
+++ b/packages/cms-lib/lib/__tests__/uploadFolder.js
@@ -7,7 +7,6 @@ jest.mock('../walk');
 jest.mock('../../api/fileMapper');
 jest.mock('../../ignoreRules');
 
-
 describe('uploadFolder', () => {
   describe('uploadFolder()', () => {
     it('uploads files in the correct order', async () => {

--- a/packages/cms-lib/lib/__tests__/uploadFolder.js
+++ b/packages/cms-lib/lib/__tests__/uploadFolder.js
@@ -1,0 +1,59 @@
+const { uploadFolder } = require('../uploadFolder');
+const { upload } = require('../../api/fileMapper');
+const { walk } = require('../walk');
+const { createIgnoreFilter } = require('../../ignoreRules');
+
+jest.mock('../walk');
+jest.mock('../../api/fileMapper');
+jest.mock('../../ignoreRules');
+
+
+describe('uploadFolder', () => {
+  describe('uploadFolder()', () => {
+    it('uploads files in the correct order', async () => {
+      const files = [
+        'folder/templates/blog.html',
+        'folder/css/file.css',
+        'folder/js/file.js',
+        'folder/images/image.png',
+        'folder/images/image.jpg',
+        'folder/sample.module/module.css',
+        'folder/sample.module/module.js',
+        'folder/sample.module/meta.json',
+        'folder/sample.module/module.html',
+        'folder/templates/page.html',
+      ];
+
+      walk.mockResolvedValue(files);
+      upload.mockImplementation(() => Promise.resolve());
+      createIgnoreFilter.mockImplementation(() => () => true);
+
+      const portalId = 123;
+      const src = 'folder';
+      const dest = 'folder';
+      const cwd = '/home/tom';
+      const uploadedFilesInOrder = [
+        'folder/images/image.png',
+        'folder/images/image.jpg',
+        'folder/sample.module/module.css',
+        'folder/sample.module/module.js',
+        'folder/sample.module/meta.json',
+        'folder/sample.module/module.html',
+        'folder/css/file.css',
+        'folder/js/file.js',
+        'folder/templates/blog.html',
+        'folder/templates/page.html',
+      ];
+
+      await uploadFolder(portalId, src, dest, { mode: 'publish', cwd });
+
+      expect(upload).toReturnTimes(10);
+
+      uploadedFilesInOrder.forEach((file, index) => {
+        expect(upload).nthCalledWith(index + 1, portalId, file, file, {
+          qs: { buffer: false },
+        });
+      });
+    });
+  });
+});

--- a/packages/cms-lib/lib/uploadFolder.js
+++ b/packages/cms-lib/lib/uploadFolder.js
@@ -7,7 +7,12 @@ const { upload } = require('../api/fileMapper');
 const { createIgnoreFilter } = require('../ignoreRules');
 const { walk } = require('./walk');
 const escapeRegExp = require('./escapeRegExp');
-const { convertToUnixPath, isAllowedExtension } = require('../path');
+const {
+  convertToUnixPath,
+  isAllowedExtension,
+  getExt,
+  splitLocalPath,
+} = require('../path');
 const {
   ApiErrorContext,
   logApiUploadErrorInstance,
@@ -18,6 +23,30 @@ const queue = new PQueue({
   concurrency: 10,
 });
 
+function getFilesByType(files) {
+  const moduleFiles = [];
+  const cssAndJsFiles = [];
+  const otherFiles = [];
+  const templateFiles = [];
+
+  files.forEach(file => {
+    const parts = splitLocalPath(file);
+    const extension = getExt(file);
+
+    const moduleFolder = parts.find(part => part.endsWith('.module'));
+    if (moduleFolder) {
+      moduleFiles.push(file);
+    } else if (extension === 'js' || extension === 'css') {
+      cssAndJsFiles.push(file);
+    } else if (extension === 'html') {
+      templateFiles.push(file);
+    } else {
+      otherFiles.push(file);
+    }
+  });
+
+  return [otherFiles, moduleFiles, cssAndJsFiles, templateFiles];
+}
 /**
  *
  * @param {number} portalId
@@ -32,7 +61,7 @@ async function uploadFolder(portalId, src, dest, { mode, cwd }) {
   };
   const files = await walk(src);
 
-  const filesToUpload = files
+  const allowedFiles = files
     .filter(file => {
       if (!isAllowedExtension(file)) {
         return false;
@@ -41,38 +70,45 @@ async function uploadFolder(portalId, src, dest, { mode, cwd }) {
     })
     .filter(createIgnoreFilter(cwd));
 
+  const filesByType = getFilesByType(allowedFiles);
+
   const failures = [];
-  await queue.addAll(
-    filesToUpload.map(file => {
-      const relativePath = file.replace(regex, '');
-      const destPath = convertToUnixPath(path.join(dest, relativePath));
-      return async () => {
-        logger.debug('Attempting to upload file "%s" to "%s"', file, destPath);
-        try {
-          await upload(portalId, file, destPath, apiOptions);
-          logger.log('Uploaded file "%s" to "%s"', file, destPath);
-        } catch (error) {
-          if (isFatalError(error)) {
-            throw error;
-          }
-          logger.debug(
-            'Uploading file "%s" to "%s" failed so scheduled retry',
-            file,
-            destPath
-          );
-          if (error.response && error.response.body) {
-            logger.debug(error.response.body);
-          } else {
-            logger.debug(error.message);
-          }
-          failures.push({
-            file,
-            destPath,
-          });
+
+  const uploadFile = file => {
+    const relativePath = file.replace(regex, '');
+    const destPath = convertToUnixPath(path.join(dest, relativePath));
+    return async () => {
+      logger.debug('Attempting to upload file "%s" to "%s"', file, destPath);
+      try {
+        await upload(portalId, file, destPath, apiOptions);
+        logger.log('Uploaded file "%s" to "%s"', file, destPath);
+      } catch (error) {
+        if (isFatalError(error)) {
+          throw error;
         }
-      };
-    })
-  );
+        logger.debug(
+          'Uploading file "%s" to "%s" failed so scheduled retry',
+          file,
+          destPath
+        );
+        if (error.response && error.response.body) {
+          logger.debug(error.response.body);
+        } else {
+          logger.debug(error.message);
+        }
+        failures.push({
+          file,
+          destPath,
+        });
+      }
+    };
+  };
+
+  for (let i = 0; i < filesByType.length; i++) {
+    const filesToUpload = filesByType[i];
+    await queue.addAll(filesToUpload.map(uploadFile));
+  }
+
   return queue.addAll(
     failures.map(({ file, destPath }) => {
       return async () => {

--- a/packages/cms-lib/lib/uploadFolder.js
+++ b/packages/cms-lib/lib/uploadFolder.js
@@ -104,6 +104,7 @@ async function uploadFolder(portalId, src, dest, { mode, cwd }) {
     };
   };
 
+  // Implemented using a for lop due to async/await
   for (let i = 0; i < filesByType.length; i++) {
     const filesToUpload = filesByType[i];
     await queue.addAll(filesToUpload.map(uploadFile));


### PR DESCRIPTION
When uploading a folder of files, it is possible for dependencies to be uploaded before files that depend on them. An example is a CSS file that references a raw asset or a template that uses a module. This decreases the likelihood that occurs through uploading file types that are often
dependencies first. This is not a perfect solution and something that should be revisited through a bulk upload endpoint that can validate after receiving all assets.

TODO:

- [x] Add some tests

@mattcoley @miketalley @corymartin 