### PR TITLE
Ensured dest dir in `create` command

### DIFF
--- a/packages/cms-cli/commands/create.js
+++ b/packages/cms-cli/commands/create.js
@@ -2,6 +2,9 @@ const path = require('path');
 const fs = require('fs-extra');
 const { version } = require('../package.json');
 
+const {
+  logFileSystemErrorInstance,
+} = require('@hubspot/cms-lib/errorHandlers');
 const { logger } = require('@hubspot/cms-lib/logger');
 const { createTheme } = require('@hubspot/cms-lib/themes');
 
@@ -66,7 +69,7 @@ function configureCreateCommand(program) {
       'Theme boilerplate version to use',
       ''
     )
-    .action((type, name, dest) => {
+    .action(async (type, name, dest) => {
       setLogLevel(program);
       logDebugInfo(program);
       type = typeof type === 'string' && type.toLowerCase();
@@ -83,14 +86,13 @@ function configureCreateCommand(program) {
       dest = resolveLocalPath(dest);
 
       try {
-        const stats = fs.statSync(dest);
-        if (!stats.isDirectory()) {
-          logger.error(`The "${dest}" is not a path to a directory`);
-          return;
-        }
+        await fs.ensureDir(dest);
       } catch (e) {
-        logger.error(`The "${dest}" is not a path to a directory`);
-        return;
+        logger.error(`The "${dest}" is not a usable path to a directory`);
+        logFileSystemErrorInstance(e, {
+          filepath: dest,
+          write: true,
+        });
       }
 
       trackCommandUsage(COMMAND_NAME, { assetType: type });

--- a/packages/cms-cli/commands/create.js
+++ b/packages/cms-cli/commands/create.js
@@ -93,6 +93,7 @@ function configureCreateCommand(program) {
           filepath: dest,
           write: true,
         });
+        return;
       }
 
       trackCommandUsage(COMMAND_NAME, { assetType: type });


### PR DESCRIPTION
Fixes #74 

If the passed `dest` directory does not exist create it.  If an error occurs in doing so, log error and exit.