### PR TITLE
Update watch.js to watch and respond to deleted folders.

### DIFF
--- a/packages/cms-lib/lib/watch.js
+++ b/packages/cms-lib/lib/watch.js
@@ -88,7 +88,7 @@ function watch(portalId, src, dest, { mode, cwd, remove, disableInitial }) {
   });
 
   if (remove) {
-    watcher.on('unlink', filePath => {
+    const deleteFileOrFolder = filePath => {
       const remotePath = getDesignManagerPath(filePath);
 
       if (shouldIgnoreFile(filePath, cwd)) {
@@ -96,14 +96,14 @@ function watch(portalId, src, dest, { mode, cwd, remove, disableInitial }) {
         return;
       }
 
-      logger.debug('Attempting to delete file "%s"', remotePath);
+      logger.debug('Attempting to delete file/folder "%s"', remotePath);
       queue.add(() => {
         deleteFile(portalId, remotePath)
           .then(() => {
-            logger.log('Deleted file "%s"', remotePath);
+            logger.log('Deleted file/folder "%s"', remotePath);
           })
           .catch(error => {
-            logger.error('Deleting file "%s" failed', remotePath);
+            logger.error('Deleting file/folder "%s" failed', remotePath);
             logApiErrorInstance(
               error,
               new ApiErrorContext({
@@ -113,7 +113,10 @@ function watch(portalId, src, dest, { mode, cwd, remove, disableInitial }) {
             );
           });
       });
-    });
+    };
+    
+    watcher.on('unlink', deleteFileOrFolder);
+    watcher.on('unlinkDir', deleteFileOrFolder);
   }
 
   watcher.on('change', file => {

--- a/packages/cms-lib/lib/watch.js
+++ b/packages/cms-lib/lib/watch.js
@@ -88,7 +88,7 @@ function watch(portalId, src, dest, { mode, cwd, remove, disableInitial }) {
   });
 
   if (remove) {
-    const deleteFileOrFolder = filePath => {
+    const deleteFileOrFolder = type => filePath => {
       const remotePath = getDesignManagerPath(filePath);
 
       if (shouldIgnoreFile(filePath, cwd)) {
@@ -96,14 +96,14 @@ function watch(portalId, src, dest, { mode, cwd, remove, disableInitial }) {
         return;
       }
 
-      logger.debug('Attempting to delete file/folder "%s"', remotePath);
+      logger.debug('Attempting to delete %s "%s"', type, remotePath);
       queue.add(() => {
         deleteFile(portalId, remotePath)
           .then(() => {
-            logger.log('Deleted file/folder "%s"', remotePath);
+            logger.log('Deleted %s "%s"', type, remotePath);
           })
           .catch(error => {
-            logger.error('Deleting file/folder "%s" failed', remotePath);
+            logger.error('Deleting %s "%s" failed', type, remotePath);
             logApiErrorInstance(
               error,
               new ApiErrorContext({
@@ -115,8 +115,8 @@ function watch(portalId, src, dest, { mode, cwd, remove, disableInitial }) {
       });
     };
     
-    watcher.on('unlink', deleteFileOrFolder);
-    watcher.on('unlinkDir', deleteFileOrFolder);
+    watcher.on('unlink', deleteFileOrFolder('file'));
+    watcher.on('unlinkDir', deleteFileOrFolder('folder'));
   }
 
   watcher.on('change', file => {


### PR DESCRIPTION
Hi All, 
George from HubSpot web team, loving experimenting with these new tools, one thing I noticed was that deleting folders weren't reflected in the design manager. which left some empty folders lying around when reorganizing within the local environment. 

This seemed like an easy and quick fix, tested it locally for this use case but not sure if there are other use cases that this might conflict with.

Feel free to let me know what you think! :D 

Cheers,
George