### PR TITLE
Update to reference "CMS" access key

### DIFF
--- a/packages/cms-cli/commands/init.js
+++ b/packages/cms-cli/commands/init.js
@@ -101,7 +101,7 @@ function initializeConfigCommand(program) {
     .description(
       `initialize ${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME} for a HubSpot portal`
     )
-    .option('--personal-access-key', 'utilize personal access key for auth')
+    .option('--personal-access-key', 'utilize personal CMS access key for auth')
     .action(async options => {
       setLogLevel(options);
       logDebugInfo(options);


### PR DESCRIPTION
Minor change to add "CMS" as part of proper name for access key.