### PR TITLE
Added additional info to logging output

### DIFF
--- a/packages/cms-lib/lib/logs.js
+++ b/packages/cms-lib/lib/logs.js
@@ -8,20 +8,28 @@ const FUNCTION_LOG_PATH = 'function.log';
 
 const logHandler = {
   UNHANDLED_ERROR: log => {
-    return `${formatTimestamp(log)} ${log.status}: ${log.error.type}: ${
+    return `${formatLogHeader(log)}\n${log.error.type}: ${
       log.error.message
-    } ${formatExecutionTime(log)}\n${formatStackTrace(log)}`;
+    }\n${formatStackTrace(log)}\n`;
   },
   HANDLED_ERROR: log => {
-    return `${formatTimestamp(log)} ${log.status}: ${log.error.type}: ${
+    return `${formatLogHeader(log)}\n${log.error.type}: ${
       log.error.message
-    } ${formatExecutionTime(log)}\n${formatStackTrace(log)}`;
+    }\n${formatStackTrace(log)}\n`;
   },
   SUCCESS: log => {
-    return `${formatTimestamp(log)} ${log.status}: ${formatPayload(
+    return `${formatLogHeader(log)}\n${formatPayload(log)}\n${formatLog(
       log
-    )} ${formatExecutionTime(log)}\n`;
+    )}\n\n`;
   },
+};
+
+const formatLogHeader = log => {
+  return `${formatTimestamp(log)} ${log.status} ${formatExecutionTime(log)}`;
+};
+
+const formatLog = log => {
+  return `${log.log}`;
 };
 
 const formatStackTrace = log => {
@@ -39,7 +47,7 @@ const formatTimestamp = log => {
 
 const formatPayload = log => {
   return util.inspect(log.payload, {
-    compact: false,
+    compact: true,
   });
 };
 

--- a/packages/cms-lib/lib/logs.js
+++ b/packages/cms-lib/lib/logs.js
@@ -20,7 +20,7 @@ const logHandler = {
   SUCCESS: log => {
     return `${formatLogHeader(log)}\n${formatPayload(log)}\n${formatLog(
       log
-    )}\n\n`;
+    )}\n`;
   },
 };
 


### PR DESCRIPTION
Included `log` prop in `hs logs` output. New output will look like:

[2020-02-19T20:13:10.681Z] UNHANDLED_ERROR (Execution Time: 2343ms)
Runtime.UserCodeSyntaxError: SyntaxError: Unexpected number

[2020-02-18T16:02:59.547Z] SUCCESS (Execution Time: 48ms)
{ body: { shh: 'secret' }, statusCode: 200 }
2020-02-18T16:02:59.586Z        INFO    test

Memory: 70/128 MB
Runtime: 4.86 ms