### PR TITLE
Refactor validateConfig()

### DIFF
--- a/packages/cms-cli/commands/auth.js
+++ b/packages/cms-cli/commands/auth.js
@@ -1,5 +1,5 @@
 const { version } = require('../package.json');
-const { loadConfig } = require('@hubspot/cms-lib');
+const { loadConfig, validateConfig } = require('@hubspot/cms-lib');
 const { logger } = require('@hubspot/cms-lib/logger');
 const {
   OAUTH_AUTH_METHOD,
@@ -10,7 +10,6 @@ const {
   personalAccessKeyPrompt,
   updateConfigWithPersonalAccessKey,
 } = require('@hubspot/cms-lib/personalAccessKey');
-const { validateConfig } = require('../lib/validation');
 const {
   addConfigOptions,
   addLoggerOptions,

--- a/packages/cms-cli/commands/fetch.js
+++ b/packages/cms-cli/commands/fetch.js
@@ -1,7 +1,7 @@
 const { version } = require('../package.json');
 
 const { downloadFileOrFolder } = require('@hubspot/cms-lib/fileMapper');
-const { loadConfig } = require('@hubspot/cms-lib');
+const { loadConfig, validateConfig } = require('@hubspot/cms-lib');
 const { logger } = require('@hubspot/cms-lib/logger');
 
 const {
@@ -15,11 +15,7 @@ const {
   setLogLevel,
 } = require('../lib/commonOpts');
 const { resolveLocalPath } = require('../lib/filesystem');
-const {
-  validateConfig,
-  validatePortal,
-  validateMode,
-} = require('../lib/validation');
+const { validatePortal, validateMode } = require('../lib/validation');
 const { logDebugInfo } = require('../lib/debugInfo');
 const {
   trackCommandUsage,

--- a/packages/cms-cli/commands/filemanager.js
+++ b/packages/cms-cli/commands/filemanager.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const { version } = require('../package.json');
 
-const { loadConfig } = require('@hubspot/cms-lib');
+const { loadConfig, validateConfig } = require('@hubspot/cms-lib');
 const { uploadFolder } = require('@hubspot/cms-lib/fileManager');
 const { uploadFile } = require('@hubspot/cms-lib/api/fileManager');
 const { getCwd, convertToUnixPath } = require('@hubspot/cms-lib/path');
@@ -23,7 +23,7 @@ const {
   getPortalId,
 } = require('../lib/commonOpts');
 const { logDebugInfo } = require('../lib/debugInfo');
-const { validateConfig, validatePortal } = require('../lib/validation');
+const { validatePortal } = require('../lib/validation');
 const {
   trackCommandUsage,
   addHelpUsageTracking,

--- a/packages/cms-cli/commands/hubdb.js
+++ b/packages/cms-cli/commands/hubdb.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { loadConfig } = require('@hubspot/cms-lib');
+const { loadConfig, validateConfig } = require('@hubspot/cms-lib');
 const { logger } = require('@hubspot/cms-lib/logger');
 const { getCwd } = require('@hubspot/cms-lib/path');
 const {
@@ -7,7 +7,7 @@ const {
   downloadHubDbTable,
 } = require('@hubspot/cms-lib/hubdb');
 
-const { validateConfig, validatePortal } = require('../lib/validation');
+const { validatePortal } = require('../lib/validation');
 const { addHelpUsageTracking } = require('../lib/usageTracking');
 const { version } = require('../package.json');
 

--- a/packages/cms-cli/commands/lint.js
+++ b/packages/cms-cli/commands/lint.js
@@ -2,7 +2,7 @@ const {
   lint,
   printHublValidationResult,
 } = require('@hubspot/cms-lib/validate');
-const { loadConfig } = require('@hubspot/cms-lib');
+const { loadConfig, validateConfig } = require('@hubspot/cms-lib');
 const { logger } = require('@hubspot/cms-lib/logger');
 const { logErrorInstance } = require('@hubspot/cms-lib/errorHandlers');
 
@@ -16,7 +16,7 @@ const {
 } = require('../lib/commonOpts');
 const { logDebugInfo } = require('../lib/debugInfo');
 const { resolveLocalPath } = require('../lib/filesystem');
-const { validateConfig, validatePortal } = require('../lib/validation');
+const { validatePortal } = require('../lib/validation');
 const {
   trackCommandUsage,
   addHelpUsageTracking,

--- a/packages/cms-cli/commands/remove.js
+++ b/packages/cms-cli/commands/remove.js
@@ -1,5 +1,5 @@
 const { deleteFile } = require('@hubspot/cms-lib/api/fileMapper');
-const { loadConfig } = require('@hubspot/cms-lib');
+const { loadConfig, validateConfig } = require('@hubspot/cms-lib');
 const { logger } = require('@hubspot/cms-lib/logger');
 const {
   logApiErrorInstance,
@@ -15,7 +15,7 @@ const {
   getPortalId,
 } = require('../lib/commonOpts');
 const { logDebugInfo } = require('../lib/debugInfo');
-const { validateConfig, validatePortal } = require('../lib/validation');
+const { validatePortal } = require('../lib/validation');
 const {
   trackCommandUsage,
   addHelpUsageTracking,

--- a/packages/cms-cli/commands/secrets.js
+++ b/packages/cms-cli/commands/secrets.js
@@ -1,8 +1,8 @@
-const { loadConfig } = require('@hubspot/cms-lib');
+const { loadConfig, validateConfig } = require('@hubspot/cms-lib');
 const { logger } = require('@hubspot/cms-lib/logger');
 const { addSecret, deleteSecret } = require('@hubspot/cms-lib/api/secrets');
 
-const { validateConfig, validatePortal } = require('../lib/validation');
+const { validatePortal } = require('../lib/validation');
 const { addHelpUsageTracking } = require('../lib/usageTracking');
 const { version } = require('../package.json');
 

--- a/packages/cms-cli/commands/server.js
+++ b/packages/cms-cli/commands/server.js
@@ -1,11 +1,10 @@
 #!/usr/bin/env node
 const path = require('path');
 const shell = require('shelljs');
-const { loadConfig } = require('@hubspot/cms-lib');
+const { loadConfig, validateConfig } = require('@hubspot/cms-lib');
 const { logger } = require('@hubspot/cms-lib/logger');
 const { getCwd } = require('@hubspot/cms-lib/path');
 
-const { validateConfig } = require('../lib/validation');
 const { version } = require('../package.json');
 const { updateServerContext } = require('../lib/server/updateContext');
 

--- a/packages/cms-cli/commands/upload.js
+++ b/packages/cms-cli/commands/upload.js
@@ -2,7 +2,11 @@ const fs = require('fs');
 const path = require('path');
 const { version } = require('../package.json');
 
-const { loadConfig, uploadFolder } = require('@hubspot/cms-lib');
+const {
+  loadConfig,
+  uploadFolder,
+  validateConfig,
+} = require('@hubspot/cms-lib');
 const {
   getFileMapperApiQueryFromMode,
 } = require('@hubspot/cms-lib/fileMapper');
@@ -31,11 +35,7 @@ const {
   getMode,
 } = require('../lib/commonOpts');
 const { logDebugInfo } = require('../lib/debugInfo');
-const {
-  validateConfig,
-  validatePortal,
-  validateMode,
-} = require('../lib/validation');
+const { validatePortal, validateMode } = require('../lib/validation');
 const {
   trackCommandUsage,
   addHelpUsageTracking,

--- a/packages/cms-cli/commands/watch.js
+++ b/packages/cms-cli/commands/watch.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const { version } = require('../package.json');
 
-const { watch, loadConfig } = require('@hubspot/cms-lib');
+const { watch, loadConfig, validateConfig } = require('@hubspot/cms-lib');
 const { getCwd } = require('@hubspot/cms-lib/path');
 const { logger } = require('@hubspot/cms-lib/logger');
 
@@ -16,11 +16,7 @@ const {
   getMode,
 } = require('../lib/commonOpts');
 const { logDebugInfo } = require('../lib/debugInfo');
-const {
-  validateConfig,
-  validatePortal,
-  validateMode,
-} = require('../lib/validation');
+const { validatePortal, validateMode } = require('../lib/validation');
 const {
   trackCommandUsage,
   addHelpUsageTracking,

--- a/packages/cms-cli/lib/validation.js
+++ b/packages/cms-cli/lib/validation.js
@@ -1,25 +1,10 @@
 const { logger } = require('@hubspot/cms-lib/logger');
-const { getConfig, getPortalConfig, Mode } = require('@hubspot/cms-lib');
+const { getPortalConfig, Mode } = require('@hubspot/cms-lib');
 const { getOauthManager } = require('@hubspot/cms-lib/oauth');
 const {
   accessTokenForPersonalAccessKey,
 } = require('@hubspot/cms-lib/personalAccessKey');
 const { getPortalId, getMode } = require('./commonOpts');
-
-/**
- * @returns {boolean}
- */
-function validateConfig() {
-  const config = getConfig();
-  if (!config) {
-    return false;
-  }
-  if (!Array.isArray(config.portals)) {
-    logger.error('config.portals[] is not defined');
-    return false;
-  }
-  return true;
-}
 
 /**
  * Validate that a portal was passed to the command and that the portal's configuration is valid
@@ -117,9 +102,6 @@ async function validatePortal(command) {
 }
 
 /**
- * Validate that a portal was passed to the command and that the portal's configuration is valid
- *
- *
  * @param {commander.Command} command
  * @returns {boolean}
  */
@@ -140,7 +122,6 @@ function validateMode(command) {
 }
 
 module.exports = {
-  validateConfig,
   validateMode,
   validatePortal,
 };

--- a/packages/cms-lib/index.js
+++ b/packages/cms-lib/index.js
@@ -6,6 +6,7 @@ const {
   getPortalId,
   getPortalConfig,
   updatePortalConfig,
+  validateConfig,
 } = require('./lib/config');
 const { uploadFolder } = require('./lib/uploadFolder');
 const { watch } = require('./lib/watch');
@@ -22,6 +23,7 @@ module.exports = {
   getPortalId,
   updatePortalConfig,
   uploadFolder,
+  validateConfig,
   watch,
   walk,
 };

--- a/packages/cms-lib/lib/config.js
+++ b/packages/cms-lib/lib/config.js
@@ -16,6 +16,47 @@ const {
 let _config;
 let _configPath;
 
+const getConfig = () => _config;
+
+const setConfig = updatedConfig => {
+  _config = updatedConfig;
+  return _config;
+};
+
+/**
+ * @returns {boolean}
+ */
+function validateConfig() {
+  const config = getConfig();
+  if (!config) {
+    logger.error('config is not defined');
+    return false;
+  }
+  if (!Array.isArray(config.portals)) {
+    logger.error('config.portals[] is not defined');
+    return false;
+  }
+  const portalsHash = {};
+  return config.portals.every(cfg => {
+    if (!cfg) {
+      logger.error('config.portals[] has an empty entry');
+      return false;
+    }
+    if (!cfg.portalId) {
+      logger.error('config.portals[] has an entry missing portalId');
+      return false;
+    }
+    if (portalsHash[cfg.portalId]) {
+      logger.error(
+        `config.portals[] has multiple entries with portalId=${cfg.portalId}`
+      );
+      return false;
+    }
+    portalsHash[cfg.portalId] = cfg;
+    return true;
+  });
+}
+
 const getOrderedConfig = unorderedConfig => {
   const {
     defaultPortal,
@@ -119,13 +160,6 @@ const getAndLoadConfigIfNeeded = () => {
       silenceErrors: true,
     });
   }
-  return _config;
-};
-
-const getConfig = () => _config;
-
-const setConfig = updatedConfig => {
-  _config = updatedConfig;
   return _config;
 };
 
@@ -314,4 +348,5 @@ module.exports = {
   createEmptyConfigFile,
   deleteEmptyConfigFile,
   isTrackingAllowed,
+  validateConfig,
 };


### PR DESCRIPTION
Fixes #78 

- Moved `validateConfig()` from `cms-cli` to `cms-lib`
- Added validation rules under `config.portal[]`
  - Can't have an empty portal entry
  - `portalId` is required
  - Can't have multiple entries with the same `portalId`
