### PR TITLE
Added nodeMajorVersion to tracking

### DIFF
--- a/packages/cms-cli/lib/usageTracking.js
+++ b/packages/cms-cli/lib/usageTracking.js
@@ -14,6 +14,11 @@ const EventClass = {
   ACTIVATION: 'ACTIVATION',
 };
 
+const getNodeVersionData = () => ({
+  nodeVersion: process.version,
+  nodeMajorVersion: (process.version || '').split('.')[0],
+});
+
 function trackCommandUsage(command, meta = {}, portalId) {
   if (!isTrackingAllowed()) {
     return;
@@ -35,7 +40,7 @@ function trackCommandUsage(command, meta = {}, portalId) {
         {
           action: 'cli-command',
           os: getPlatform(),
-          nodeVersion: process.version,
+          ...getNodeVersionData(),
           version,
           command,
           authType,
@@ -62,7 +67,7 @@ async function trackHelpUsage(command) {
     await trackUsage('cli-interaction', EventClass.INTERACTION, {
       action: 'cli-help',
       os: getPlatform(),
-      nodeVersion: process.version,
+      ...getNodeVersionData(),
       version,
       command,
     });

--- a/packages/cms-cli/lib/usageTracking.js
+++ b/packages/cms-cli/lib/usageTracking.js
@@ -91,7 +91,7 @@ const trackAuthAction = async (command, authType, step) => {
     return await trackUsage('cli-interaction', EventClass.INTERACTION, {
       action: 'cli-auth',
       os: getPlatform(),
-      nodeVersion: process.version,
+      ...getNodeVersionData(),
       version,
       command,
       authType,


### PR DESCRIPTION
This adds `nodeMajorVersion` in addition to the existing `nodeVersion`.  The major version is easier to group.  It's format is `"v10"`, `"v11"`, etc.

/cc @bkrainer @gcorne @miketalley 