### PR TITLE
Fixed config reference path

### DIFF
--- a/packages/cms-cli/commands/init.js
+++ b/packages/cms-cli/commands/init.js
@@ -3,7 +3,7 @@ const {
   getConfigPath,
   createEmptyConfigFile,
   deleteEmptyConfigFile,
-} = require('@hubspot/cms-lib/config');
+} = require('@hubspot/cms-lib/lib/config');
 const { handleExit } = require('@hubspot/cms-lib/lib/process');
 const {
   logFileSystemErrorInstance,


### PR DESCRIPTION
Fixes error

```
BOSMM2YR097LVCJ:Prod mtalley$ hs init
internal/modules/cjs/loader.js:797
    throw err;
    ^

Error: Cannot find module '@hubspot/cms-lib/config'
Require stack:
- /usr/local/lib/node_modules/@hubspot/cms-cli/commands/init.js
- /usr/local/lib/node_modules/@hubspot/cms-cli/bin/hs-init.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:794:15)
    at Function.Module._load (internal/modules/cjs/loader.js:687:27)
    at Module.require (internal/modules/cjs/loader.js:849:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (/usr/local/lib/node_modules/@hubspot/cms-cli/commands/init.js:6:5)
    at Module._compile (internal/modules/cjs/loader.js:956:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:973:10)
    at Module.load (internal/modules/cjs/loader.js:812:32)
    at Function.Module._load (internal/modules/cjs/loader.js:724:14)
    at Module.require (internal/modules/cjs/loader.js:849:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/usr/local/lib/node_modules/@hubspot/cms-cli/commands/init.js',
    '/usr/local/lib/node_modules/@hubspot/cms-cli/bin/hs-init.js'
  ]
}
```