### PR TITLE
Guard against requesting empty paths from CDN

### DIFF
--- a/packages/cms-lib/fileMapper.js
+++ b/packages/cms-lib/fileMapper.js
@@ -236,6 +236,10 @@ async function skipExisting(input, filepath) {
  * @param {string} filepath - Local path to write to.
  */
 async function fetchAndWriteFileStream(input, srcPath, filepath) {
+  if (typeof srcPath !== 'string' || !srcPath.trim()) {
+    // This avoids issue where API was returning v1 modules with `path: ""`
+    return null;
+  }
   if (await skipExisting(input, filepath)) {
     return null;
   }


### PR DESCRIPTION
There were cases in which the filemapper API was retuning empty results for v1 modules.
This adds a guard clause to treat that as a noop when fetching.

/cc @bkrainer 