### PR TITLE
Add hs secrets list command

### DIFF
--- a/packages/cms-cli/bin/hs-secrets-list.js
+++ b/packages/cms-cli/bin/hs-secrets-list.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+const { Command } = require('commander');
+
+const { configureSecretsListCommand } = require('../commands/secrets');
+
+const program = new Command('hs secrets list');
+configureSecretsListCommand(program);
+program.parse(process.argv);

--- a/packages/cms-cli/bin/hscms-secrets-list.js
+++ b/packages/cms-cli/bin/hscms-secrets-list.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+const { Command } = require('commander');
+
+const { configureSecretsListCommand } = require('../commands/secrets');
+
+const program = new Command('hscms secrets list');
+configureSecretsListCommand(program);
+program.parse(process.argv);

--- a/packages/cms-cli/commands/secrets.js
+++ b/packages/cms-cli/commands/secrets.js
@@ -47,18 +47,10 @@ function configureSecretsAddCommand(program) {
       loadConfig(configPath);
       checkAndWarnGitInclusion();
 
-      console.log(
-        'Before validate',
-        validateConfig(),
-        await validatePortal(command)
-      );
-
       if (!(validateConfig() && (await validatePortal(command)))) {
         process.exit(1);
       }
       const portalId = getPortalId(command);
-
-      console.log('Portal ID: ', portalId);
 
       try {
         await addSecret(portalId, secretName, secretValue);

--- a/packages/cms-cli/commands/secrets.js
+++ b/packages/cms-cli/commands/secrets.js
@@ -4,10 +4,11 @@ const {
   checkAndWarnGitInclusion,
 } = require('@hubspot/cms-lib');
 const { logger } = require('@hubspot/cms-lib/logger');
+const { logErrorInstance } = require('@hubspot/cms-lib/errorHandlers');
 const {
   addSecret,
   deleteSecret,
-  getSecrets,
+  fetchSecrets,
 } = require('@hubspot/cms-lib/api/secrets');
 
 const { validatePortal } = require('../lib/validation');
@@ -23,12 +24,14 @@ const {
 } = require('../lib/commonOpts');
 const { logDebugInfo } = require('../lib/debugInfo');
 
+const COMMAND_NAME = 'secrets';
+
 function configureSecretsCommand(program) {
   program
     .version(version)
     .description('Manage secrets')
-    .command('add <secret-name> <secret-value>', 'add a HubSpot secret')
-    .command('delete <secret-name>', 'delete a HubSpot secret')
+    .command('add <name> <value>', 'add a HubSpot secret')
+    .command('delete <name>', 'delete a HubSpot secret')
     .command('list', 'list all HubSpot secrets');
 
   addLoggerOptions(program);
@@ -39,18 +42,18 @@ function configureSecretsAddCommand(program) {
   program
     .version(version)
     .description('Add a HubSpot secret')
-    .arguments('<secret-name> <secret-value>')
-    .action(async (secretName, secretValue, command = {}) => {
-      setLogLevel(command);
-      logDebugInfo(command);
-      const { config: configPath } = command;
+    .arguments('<name> <value>')
+    .action(async (secretName, secretValue) => {
+      setLogLevel(program);
+      logDebugInfo(program);
+      const { config: configPath } = program;
       loadConfig(configPath);
       checkAndWarnGitInclusion();
 
-      if (!(validateConfig() && (await validatePortal(command)))) {
+      if (!(validateConfig() && (await validatePortal(program)))) {
         process.exit(1);
       }
-      const portalId = getPortalId(command);
+      const portalId = getPortalId(program);
 
       try {
         await addSecret(portalId, secretName, secretValue);
@@ -58,8 +61,11 @@ function configureSecretsAddCommand(program) {
           `The secret "${secretName}" was added to the HubSpot portal: ${portalId}`
         );
       } catch (e) {
-        logger.error(`Adding secret "${secretName}" failed`);
-        logger.error(e.message);
+        logErrorInstance(e, {
+          command: `${COMMAND_NAME} add`,
+          portalId,
+          secretName,
+        });
       }
     });
 
@@ -72,17 +78,17 @@ function configureSecretsDeleteCommand(program) {
   program
     .version(version)
     .description('Delete a HubSpot secret')
-    .arguments('<secret-name>')
-    .action(async (secretName, command = {}) => {
-      setLogLevel(command);
-      logDebugInfo(command);
-      const { config: configPath } = command;
+    .arguments('<name>')
+    .action(async secretName => {
+      setLogLevel(program);
+      logDebugInfo(program);
+      const { config: configPath } = program;
       loadConfig(configPath);
 
-      if (!(validateConfig() && (await validatePortal(command)))) {
+      if (!(validateConfig() && (await validatePortal(program)))) {
         process.exit(1);
       }
-      const portalId = getPortalId(command);
+      const portalId = getPortalId(program);
 
       try {
         await deleteSecret(portalId, secretName);
@@ -90,8 +96,11 @@ function configureSecretsDeleteCommand(program) {
           `The secret "${secretName}" was deleted from the HubSpot portal: ${portalId}`
         );
       } catch (e) {
-        logger.error(`Deleting secret "${secretName}" failed`);
-        logger.error(e.message);
+        logErrorInstance(e, {
+          command: `${COMMAND_NAME} delete`,
+          portalId,
+          secretName,
+        });
       }
     });
 
@@ -104,24 +113,28 @@ function configureSecretsListCommand(program) {
   program
     .version(version)
     .description('List all HubSpot secrets')
-    .action(async (options = {}) => {
-      setLogLevel(options);
-      logDebugInfo(options);
-      const { config: configPath } = options;
+    .action(async () => {
+      setLogLevel(program);
+      logDebugInfo(program);
+      const { config: configPath } = program;
       loadConfig(configPath);
 
-      if (!(validateConfig() && (await validatePortal(options)))) {
+      if (!(validateConfig() && (await validatePortal(program)))) {
         process.exit(1);
       }
-      const portalId = getPortalId(options);
+      const portalId = getPortalId(program);
 
       try {
-        const { results } = await getSecrets(portalId);
-        logger.log(`Secrets for portal: ${portalId}:`);
+        const { results } = await fetchSecrets(portalId);
+        const groupLabel = `Secrets for portal ${portalId}:`;
+        logger.group(groupLabel);
         results.forEach(secret => logger.log(secret));
+        logger.groupEnd(groupLabel);
       } catch (e) {
-        logger.error('Getting secrets failed');
-        logger.error(e.message);
+        logErrorInstance(e, {
+          command: `${COMMAND_NAME} list`,
+          portalId,
+        });
       }
     });
 

--- a/packages/cms-lib/api/secrets.js
+++ b/packages/cms-lib/api/secrets.js
@@ -18,7 +18,14 @@ async function deleteSecret(portalId, key) {
   });
 }
 
+async function getSecrets(portalId) {
+  return http.get(portalId, {
+    uri: `${SECRETS_API_PATH}`,
+  });
+}
+
 module.exports = {
   addSecret,
   deleteSecret,
+  getSecrets,
 };

--- a/packages/cms-lib/api/secrets.js
+++ b/packages/cms-lib/api/secrets.js
@@ -18,7 +18,7 @@ async function deleteSecret(portalId, key) {
   });
 }
 
-async function getSecrets(portalId) {
+async function fetchSecrets(portalId) {
   return http.get(portalId, {
     uri: `${SECRETS_API_PATH}`,
   });
@@ -27,5 +27,5 @@ async function getSecrets(portalId) {
 module.exports = {
   addSecret,
   deleteSecret,
-  getSecrets,
+  fetchSecrets,
 };


### PR DESCRIPTION
- Allows `hs secrets list` command to be used to display the names of the secrets that are set for the portal specified

![image](https://user-images.githubusercontent.com/6472448/76231759-13333f80-61fc-11ea-9c57-55b64338ab5a.png)