### PR TITLE
Allow fetch to work with extended characters

### DIFF
--- a/packages/cms-lib/api/fileMapper.js
+++ b/packages/cms-lib/api/fileMapper.js
@@ -91,7 +91,7 @@ async function fetchFileStream(portalId, filePath, destination, options = {}) {
   const response = await http.getOctetStream(
     portalId,
     {
-      uri: `${FILE_MAPPER_API_PATH}/stream/${filePath}`,
+      uri: `${FILE_MAPPER_API_PATH}/stream${filePath}`,
       ...options,
     },
     destination

--- a/packages/cms-lib/api/fileMapper.js
+++ b/packages/cms-lib/api/fileMapper.js
@@ -91,7 +91,7 @@ async function fetchFileStream(portalId, filePath, destination, options = {}) {
   const response = await http.getOctetStream(
     portalId,
     {
-      uri: `${FILE_MAPPER_API_PATH}/stream${filePath}`,
+      uri: `${FILE_MAPPER_API_PATH}/stream/${encodeURIComponent(filePath)}`,
       ...options,
     },
     destination

--- a/packages/cms-lib/http.js
+++ b/packages/cms-lib/http.js
@@ -106,15 +106,8 @@ const createGetRequestStream = ({ contentType }) => async (
   options,
   destination
 ) => {
-  const { query, uri, ...rest } = options;
-  const requestOptions = addQueryParams(
-    {
-      ...rest,
-      // Handle extended characters(kanji, etc)
-      uri: encodeURI(uri),
-    },
-    query
-  );
+  const { query, ...rest } = options;
+  const requestOptions = addQueryParams(rest, query);
   // Using `request` instead of `request-promise` per the docs so
   // the response can be piped.
   // https://github.com/request/request-promise#api-in-detail

--- a/packages/cms-lib/http.js
+++ b/packages/cms-lib/http.js
@@ -110,7 +110,7 @@ const createGetRequestStream = ({ contentType }) => async (
   const requestOptions = addQueryParams(
     {
       ...rest,
-      // Handle kanji
+      // Handle extended characters(kanji, etc)
       uri: encodeURI(uri),
     },
     query

--- a/packages/cms-lib/http.js
+++ b/packages/cms-lib/http.js
@@ -106,8 +106,15 @@ const createGetRequestStream = ({ contentType }) => async (
   options,
   destination
 ) => {
-  const { query, ...rest } = options;
-  const requestOptions = addQueryParams(rest, query);
+  const { query, uri, ...rest } = options;
+  const requestOptions = addQueryParams(
+    {
+      ...rest,
+      // Handle kanji
+      uri: encodeURI(uri),
+    },
+    query
+  );
   // Using `request` instead of `request-promise` per the docs so
   // the response can be piped.
   // https://github.com/request/request-promise#api-in-detail


### PR DESCRIPTION
Kanji characters in filenames were causing the `hs fetch` command to encounter an error due to "unescaped characters".

- Escape `uri` before sending request for file to backend

Fixes #135 