### PR TITLE
Config source control warning only shows when necessary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,7 @@ node_modules
 tmp
 context
 coverage
-hubspot.config.yml
-hubspot.config.yaml
+hubspot.config.*
 lerna-debug.log
 npm-debug.log
 npm-debug.log.*

--- a/packages/cms-lib/lib/config.js
+++ b/packages/cms-lib/lib/config.js
@@ -125,6 +125,8 @@ const isConfigPathInGitRepo = () => {
   return configDir.startsWith(gitDir);
 };
 
+const CONFIG_FILE_WILDCARD_MATCHER = 'hubspot.config.*';
+
 const configFilenameIsIgnoredByGitignore = () => {
   const ignoreFiles = getGitignoreFiles();
   const configPathSegments = _configPath.split('/');
@@ -135,10 +137,10 @@ const configFilenameIsIgnoredByGitignore = () => {
       .readFileSync(gitignore, 'utf8')
       .split('\n')
       .filter(i => i);
+    const gitignoreConfig = ignore().add(gitignoreContents);
     if (
-      ignore()
-        .add(gitignoreContents)
-        .ignores(configFilename)
+      gitignoreConfig.ignores(configFilename) ||
+      gitignoreConfig.ignores(CONFIG_FILE_WILDCARD_MATCHER)
     ) {
       // Has a gitignore rule
       return true;
@@ -167,7 +169,7 @@ const checkAndWarnGitInclusion = () => {
   logger.warn(`File: "${_configPath}"`);
   logger.warn(`To remediate:
   - Move config file to your home directory: "${os.homedir()}"
-  - Add gitignore pattern "hubspot.config.*" to a .gitignore file in root of your repository.
+  - Add gitignore pattern "${CONFIG_FILE_WILDCARD_MATCHER}" to a .gitignore file in root of your repository.
   - Ensure that config file has not already been pushed to a remote repository.
 `);
 };


### PR DESCRIPTION
From what I can tell, this was not working properly, but was masked by the fact that the config location was moved to `/Users/<username>`. If I have a `hubspot.config.yml` file in my project directory and have also added `hubspot.config.yml` to my `.gitignore` this message is still triggered(false positive).

I changed the way that we are checking if the config file is ignored properly and also made it more dynamic so it works with `hubspot.config.yml` and `hubspot.config.yaml`(based on what the config file extension is) as well as `hubspot.config.*`(which catches both).