### PR TITLE
Fix fetch defaults

### DIFF
--- a/packages/cms-lib/api/fileMapper.js
+++ b/packages/cms-lib/api/fileMapper.js
@@ -116,6 +116,22 @@ async function download(portalId, filepath, options = {}) {
 }
 
 /**
+ * Fetch a folder or file node by path.
+ *
+ * @async
+ * @param {number} portalId
+ * @param {string} filepath
+ * @param {object} options
+ * @returns {Promise<FileMapperNode>}
+ */
+async function downloadDefault(portalId, filepath, options = {}) {
+  return http.get(portalId, {
+    uri: `${FILE_MAPPER_API_PATH}/download-default/${filepath}`,
+    ...options,
+  });
+}
+
+/**
  * Delete a file or folder by path
  *
  * @async
@@ -191,6 +207,7 @@ module.exports = {
   deleteFile,
   deleteFolder,
   download,
+  downloadDefault,
   fetchFileStream,
   fetchModule,
   trackUsage,

--- a/packages/cms-lib/fileMapper.js
+++ b/packages/cms-lib/fileMapper.js
@@ -357,7 +357,7 @@ function isTimeout(err) {
 // @hubspot assets have a periodic delay due to caching
 function logHubspotAssetTimeout() {
   logger.error(
-    '@hubspot assets are unavailable at the moment. Please wait a few minutes and try again'
+    'HubSpot assets are unavailable at the moment. Please wait a few minutes and try again.'
   );
 }
 

--- a/packages/cms-lib/fileMapper.js
+++ b/packages/cms-lib/fileMapper.js
@@ -350,6 +350,10 @@ async function writeFileMapperNode(input, node, filepath) {
   }
 }
 
+function isTimeout(err) {
+  return !!err && (err.statusCode === 408 || err.code === 'ESOCKETTIMEDOUT');
+}
+
 // @hubspot assets have a periodic delay due to caching
 function logHubspotAssetTimeout() {
   logger.error(
@@ -391,7 +395,7 @@ async function downloadFile(input) {
     await queue.onIdle();
     logger.log('Completed fetch of file "%s" to "%s"', input.src, localFsPath);
   } catch (err) {
-    if (isHubspot && err.statusCode === 408) {
+    if (isHubspot && isTimeout(err)) {
       logHubspotAssetTimeout();
     } else {
       logger.error('Failed fetch of file "%s" to "%s"', input.src, input.dest);
@@ -420,7 +424,7 @@ async function fetchFolderFromApi(input) {
     logger.log('Fetched "%s" from portal %d successfully', src, portalId);
     return node;
   } catch (err) {
-    if (isHubspot && err.statusCode === 408) {
+    if (isHubspot && isTimeout(err)) {
       logHubspotAssetTimeout();
     } else {
       logApiErrorInstance(


### PR DESCRIPTION
- For `@hubspot` folder fetches, switched to `/download-default` endpoint.
- Added error message for timeouts to above API.  This API has periodic caching which will cause a timeout but we have high confidence it will work again a couple of minutes.

