### PR TITLE
Added and to lists in help text

### DIFF
--- a/packages/cms-cli/commands/auth.js
+++ b/packages/cms-cli/commands/auth.js
@@ -25,12 +25,16 @@ const {
   addHelpUsageTracking,
 } = require('../lib/usageTracking');
 const { promptUser, OAUTH_FLOW } = require('../lib/prompts');
+const { commaSeparatedValues } = require('../lib/text');
 
 const COMMAND_NAME = 'auth';
 const ALLOWED_AUTH_METHODS = [
   OAUTH_AUTH_METHOD.value,
   PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
 ];
+const SUPPORTED_AUTHENTICATION_PROTOCOLS_TEXT = commaSeparatedValues(
+  ALLOWED_AUTH_METHODS
+);
 
 async function authAction(type, options) {
   const authType = type.toLowerCase();
@@ -59,9 +63,7 @@ async function authAction(type, options) {
       break;
     default:
       logger.error(
-        `Unsupported auth type: ${type}. The only supported authentication protocols are ${ALLOWED_AUTH_METHODS.join(
-          ', '
-        )}.`
+        `Unsupported auth type: ${type}. The only supported authentication protocols are ${SUPPORTED_AUTHENTICATION_PROTOCOLS_TEXT}.`
       );
       break;
   }
@@ -72,9 +74,7 @@ function configureAuthCommand(program) {
   program
     .version(version)
     .description(
-      `Configure authentication for a HubSpot account. Supported authentication protocols are ${ALLOWED_AUTH_METHODS.join(
-        ', '
-      )}.`
+      `Configure authentication for a HubSpot account. Supported authentication protocols are ${SUPPORTED_AUTHENTICATION_PROTOCOLS_TEXT}.`
     )
     .arguments('<type>')
     .action(authAction);

--- a/packages/cms-cli/commands/create.js
+++ b/packages/cms-cli/commands/create.js
@@ -18,6 +18,7 @@ const {
   addHelpUsageTracking,
 } = require('../lib/usageTracking');
 const { createFunctionPrompt } = require('../lib/createFunctionPrompt');
+const { commaSeparatedValues } = require('../lib/text');
 
 const COMMAND_NAME = 'create';
 
@@ -37,6 +38,8 @@ const ASSET_PATHS = {
     '../defaults/global-partial.html'
   ),
 };
+
+const SUPPORTED_ASSET_TYPES = commaSeparatedValues(Object.values(TYPES));
 
 const createModule = (name, dest) => {
   const assetPath = ASSET_PATHS.module;
@@ -70,9 +73,7 @@ function configureCreateCommand(program) {
   program
     .version(version)
     .description(
-      `Create HubSpot CMS assets. Supported assets are ${Object.values(
-        TYPES
-      ).join(', ')}.`
+      `Create HubSpot CMS assets. Supported assets are ${SUPPORTED_ASSET_TYPES}.`
     )
     // For a theme or function this is `<type> <dest>`
     // TODO: Yargs allows an array of commands.
@@ -88,9 +89,7 @@ function configureCreateCommand(program) {
       type = typeof type === 'string' && type.toLowerCase();
       if (!type || !TYPES[type]) {
         logger.error(
-          `The asset type ${type} is not supported. Supported authentication protocols are ${Object.values(
-            TYPES
-          ).join(', ')}.`
+          `The asset type ${type} is not supported. Supported authentication protocols are ${SUPPORTED_ASSET_TYPES}.`
         );
         return;
       }

--- a/packages/cms-cli/lib/text.js
+++ b/packages/cms-cli/lib/text.js
@@ -1,0 +1,13 @@
+const commaSeparatedValues = (arr, conjunction = 'and', ifempty = '') => {
+  let l = arr.length;
+  if (!l) return ifempty;
+  if (l < 2) return arr[0];
+  if (l < 3) return arr.join(` ${conjunction} `);
+  arr = arr.slice();
+  arr[l - 1] = `${conjunction} ${arr[l - 1]}`;
+  return arr.join(', ');
+};
+
+module.exports = {
+  commaSeparatedValues,
+};


### PR DESCRIPTION
Adds 'and' to lists of items specified in help text when a subcommand is not specified.

For example when running `hs create` we now display

```Create HubSpot CMS assets. Supported assets are function, global-partial, module, template, and website-theme.```

instead of 

```Create HubSpot CMS assets. Supported assets are function, global-partial, module, template, website-theme.```