### PR TITLE
Added --qa flag to hs auth and hs init

### DIFF
--- a/packages/cms-cli/commands/auth.js
+++ b/packages/cms-cli/commands/auth.js
@@ -8,6 +8,7 @@ const { logger } = require('@hubspot/cms-lib/logger');
 const {
   OAUTH_AUTH_METHOD,
   PERSONAL_ACCESS_KEY_AUTH_METHOD,
+  ENVIRONMENTS,
 } = require('@hubspot/cms-lib/lib/constants');
 const { authenticateWithOauth } = require('@hubspot/cms-lib/oauth');
 const {
@@ -18,6 +19,7 @@ const {
   addConfigOptions,
   addLoggerOptions,
   setLogLevel,
+  addTestingOptions,
 } = require('../lib/commonOpts');
 const { logDebugInfo } = require('../lib/debugInfo');
 const {
@@ -41,6 +43,7 @@ async function authAction(type, options) {
   setLogLevel(options);
   logDebugInfo(options);
   const { config: configPath } = options;
+  const env = options.qa ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD;
   loadConfig(configPath, {
     ignoreEnvironmentVariableConfig: true,
   });
@@ -55,10 +58,13 @@ async function authAction(type, options) {
   switch (authType) {
     case OAUTH_AUTH_METHOD.value:
       configData = await promptUser(OAUTH_FLOW);
-      await authenticateWithOauth(configData);
+      await authenticateWithOauth({
+        ...configData,
+        env,
+      });
       break;
     case PERSONAL_ACCESS_KEY_AUTH_METHOD.value:
-      configData = await personalAccessKeyPrompt();
+      configData = await personalAccessKeyPrompt({ env });
       await updateConfigWithPersonalAccessKey(configData);
       break;
     default:
@@ -81,6 +87,7 @@ function configureAuthCommand(program) {
 
   addLoggerOptions(program);
   addConfigOptions(program);
+  addTestingOptions(program);
   addHelpUsageTracking(program, COMMAND_NAME);
 }
 

--- a/packages/cms-cli/commands/init.js
+++ b/packages/cms-cli/commands/init.js
@@ -10,6 +10,7 @@ const { logErrorInstance } = require('@hubspot/cms-lib/errorHandlers');
 const {
   DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
   PERSONAL_ACCESS_KEY_AUTH_METHOD,
+  ENVIRONMENTS,
 } = require('@hubspot/cms-lib/lib/constants');
 const { logger } = require('@hubspot/cms-lib/logger');
 const {
@@ -21,7 +22,11 @@ const {
   addHelpUsageTracking,
   trackAuthAction,
 } = require('../lib/usageTracking');
-const { addLoggerOptions, setLogLevel } = require('../lib/commonOpts');
+const {
+  addLoggerOptions,
+  setLogLevel,
+  addTestingOptions,
+} = require('../lib/commonOpts');
 const { logDebugInfo } = require('../lib/debugInfo');
 
 const COMMAND_NAME = 'init';
@@ -43,6 +48,7 @@ function initializeConfigCommand(program) {
       trackCommandUsage(COMMAND_NAME, { authType: 'personalaccesskey' });
 
       const configPath = getConfigPath();
+      const env = options.qa ? ENVIRONMENTS.QA : ENVIRONMENTS.PROD;
 
       if (configPath) {
         logger.error(`The config file '${configPath}' already exists.`);
@@ -62,7 +68,7 @@ function initializeConfigCommand(program) {
       handleExit(deleteEmptyConfigFile);
 
       try {
-        const configData = await personalAccessKeyPrompt();
+        const configData = await personalAccessKeyPrompt({ env });
         await updateConfigWithPersonalAccessKey(configData, true);
         const portalId = getPortalId();
         trackAuthAction(
@@ -82,6 +88,7 @@ function initializeConfigCommand(program) {
     });
 
   addLoggerOptions(program);
+  addTestingOptions(program);
   addHelpUsageTracking(program, COMMAND_NAME);
 }
 

--- a/packages/cms-cli/lib/commonOpts.js
+++ b/packages/cms-cli/lib/commonOpts.js
@@ -34,6 +34,10 @@ const addModeOptions = (program, { read, write }) => {
   program.option('--mode <mode>', help);
 };
 
+const addTestingOptions = program => {
+  program.option('--qa', 'run command in qa mode', false);
+};
+
 const setLogLevel = (options = {}) => {
   const { debug } = options;
   if (debug) {
@@ -82,6 +86,7 @@ module.exports = {
   addConfigOptions,
   addOverwriteOptions,
   addModeOptions,
+  addTestingOptions,
   setLogLevel,
   getPortalId,
   getMode,

--- a/packages/cms-cli/lib/prompts.js
+++ b/packages/cms-cli/lib/prompts.js
@@ -13,7 +13,7 @@ const promptUser = async promptConfig => {
 const PORTAL_ID = {
   name: 'portalId',
   message:
-    'Enter the portal ID for your account (the number under the DOMAIN column at https://app.hubspot.com/myaccounts-beta):',
+    'Enter the portal ID for your account (the number under the DOMAIN column at https://app.hubspot.com/myaccounts-beta ):',
   type: 'number',
   validate(val) {
     if (!Number.isNaN(val) && val > 0) {

--- a/packages/cms-lib/lib/config.js
+++ b/packages/cms-lib/lib/config.js
@@ -68,6 +68,18 @@ const validateConfig = () => {
   });
 };
 
+const getOrderedPortal = unorderedPortal => {
+  const { name, portalId, env, authType, ...rest } = unorderedPortal;
+
+  return {
+    name,
+    portalId,
+    env,
+    authType,
+    ...rest,
+  };
+};
+
 const getOrderedConfig = unorderedConfig => {
   const {
     defaultPortal,
@@ -83,7 +95,7 @@ const getOrderedConfig = unorderedConfig => {
     defaultMode,
     httpTimeout,
     allowsUsageTracking,
-    portals,
+    portals: portals.map(getOrderedPortal),
     ...rest,
   };
 };

--- a/packages/cms-lib/oauth.js
+++ b/packages/cms-lib/oauth.js
@@ -44,7 +44,7 @@ const setupOauth = (portalId, portalConfig) => {
   return new OAuth2Manager(
     {
       ...portalConfig,
-      environment: config.env || ENVIRONMENTS.PROD,
+      environment: portalConfig.env || config.env || ENVIRONMENTS.PROD,
     },
     logger
   );

--- a/packages/cms-lib/personalAccessKey.js
+++ b/packages/cms-lib/personalAccessKey.js
@@ -138,7 +138,7 @@ async function accessTokenForPersonalAccessKey(portalId) {
 /**
  * Prompts user for portal name, then opens their browser to the shortlink to personal-access-key
  */
-const personalAccessKeyPrompt = async ({ env }) => {
+const personalAccessKeyPrompt = async ({ env } = {}) => {
   const { name } = await promptUser(PERSONAL_ACCESS_KEY_FLOW);
   const portalId = getPortalId(name);
   const websiteOrigin = getHubSpotWebsiteOrigin(env || getEnv(name));


### PR DESCRIPTION
- Adds `--qa` flag to `hs init` and `hs auth` commands to add portal entry in config as QA portal
  - Opens correct browser URL based on flag
- Portal config properties are ordered consistently when writing config
  1. [`name`]
  1. `portalId`
  1. [`env`]
  1. `authType`
  1. `...rest`