### PR TITLE
QA option is hidden from help text

### DIFF
--- a/packages/cms-cli/lib/commonOpts.js
+++ b/packages/cms-cli/lib/commonOpts.js
@@ -35,7 +35,20 @@ const addModeOptions = (program, { read, write }) => {
 };
 
 const addTestingOptions = program => {
-  program.option('--qa', 'run command in qa mode', false);
+  const qaFlagOption = '--qa';
+  program.option(qaFlagOption, 'run command in qa mode', false);
+
+  // This allows us to hide the output of this option in the help text
+  // because commander does not support hiding it
+  // see https://github.com/tj/commander.js/issues/811
+  program.help(output => {
+    return output
+      .split('\n')
+      .filter(
+        helpTextLineContent => helpTextLineContent.indexOf(qaFlagOption) === -1
+      )
+      .join('\n');
+  });
 };
 
 const setLogLevel = (options = {}) => {

--- a/packages/cms-lib/personalAccessKey.js
+++ b/packages/cms-lib/personalAccessKey.js
@@ -164,11 +164,11 @@ const personalAccessKeyPrompt = async ({ env } = {}) => {
  */
 const updateConfigWithPersonalAccessKey = async (configData, makeDefault) => {
   const { personalAccessKey, name, env } = configData;
-  const accessKeyEnv = env || getEnv(name);
+  const portalEnv = env || getEnv(name);
 
   let token;
   try {
-    token = await getAccessToken(personalAccessKey, accessKeyEnv);
+    token = await getAccessToken(personalAccessKey, portalEnv);
   } catch (err) {
     logErrorInstance(err);
     return;
@@ -179,7 +179,7 @@ const updateConfigWithPersonalAccessKey = async (configData, makeDefault) => {
     portalId,
     personalAccessKey,
     name,
-    environment: getValidEnv(accessKeyEnv, true),
+    environment: getValidEnv(portalEnv, true),
     authType: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
     tokenInfo: { accessToken, expiresAt },
   });


### PR DESCRIPTION
- Hides `--qa` option from help text on associated commands
- Renamed a variable for clarity