### PR TITLE
Add clear and delete commands

### DIFF
--- a/packages/cms-cli/bin/hs-hubdb-clear.js
+++ b/packages/cms-cli/bin/hs-hubdb-clear.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+const { Command } = require('commander');
+
+const { configureHubDbClearCommand } = require('../commands/hubdb');
+
+const program = new Command('hs hubdb clear');
+configureHubDbClearCommand(program);
+program.parse(process.argv);

--- a/packages/cms-cli/bin/hs-hubdb-delete.js
+++ b/packages/cms-cli/bin/hs-hubdb-delete.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+const { Command } = require('commander');
+
+const { configureHubDbDeleteCommand } = require('../commands/hubdb');
+
+const program = new Command('hs hubdb delete');
+configureHubDbDeleteCommand(program);
+program.parse(process.argv);

--- a/packages/cms-cli/bin/hscms-hubdb-clear.js
+++ b/packages/cms-cli/bin/hscms-hubdb-clear.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+const { Command } = require('commander');
+
+const { configureHubDbClearCommand } = require('../commands/hubdb');
+
+const program = new Command('hscms hubdb clear');
+configureHubDbClearCommand(program);
+program.parse(process.argv);

--- a/packages/cms-cli/bin/hscms-hubdb-delete.js
+++ b/packages/cms-cli/bin/hscms-hubdb-delete.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+const { Command } = require('commander');
+
+const { configureHubDbDeleteCommand } = require('../commands/hubdb');
+
+const program = new Command('hscms hubdb delete');
+configureHubDbDeleteCommand(program);
+program.parse(process.argv);

--- a/packages/cms-cli/commands/hubdb.js
+++ b/packages/cms-cli/commands/hubdb.js
@@ -100,7 +100,7 @@ function configureHubDbFetchCommand(program) {
         );
         logger.log(`Downloaded HubDB table ${tableId} to ${dest}`);
       } catch (e) {
-        logger.error(e);
+        logErrorInstance(e);
       }
     });
 
@@ -138,7 +138,7 @@ function configureHubDbClearCommand(program) {
           logger.log(`HubDB table ${tableId} is already empty`);
         }
       } catch (e) {
-        logger.error(e);
+        logErrorInstance(e);
       }
     });
 

--- a/packages/cms-lib/hubdb.js
+++ b/packages/cms-lib/hubdb.js
@@ -182,7 +182,7 @@ async function clearHubDbTableRows(portalId, tableId) {
     const rowIds = response.objects.map(row => row.id);
     rows = rows.concat(rowIds);
   }
-  await deleteRows(portalId, tableId, rows);
+  return deleteRows(portalId, tableId, rows);
 }
 
 module.exports = {


### PR DESCRIPTION
Adds 2 new HubDB actions to for HubDB:

`clear`: looks up all rows, deletes them, publishes the table
`delete`: deletes a table
﻿﻿
![image](https://user-images.githubusercontent.com/9009552/81927413-9896ef80-95b1-11ea-9275-af71c190255f.png)

Fixes #192 