### PR TITLE
Support working with hubdb via table name

### DIFF
--- a/packages/cms-cli/commands/hubdb.js
+++ b/packages/cms-cli/commands/hubdb.js
@@ -10,7 +10,6 @@ const { getCwd } = require('@hubspot/cms-lib/path');
 const {
   createHubDbTable,
   downloadHubDbTable,
-  getTableId,
 } = require('@hubspot/cms-lib/hubdb');
 
 const { validatePortal } = require('../lib/validation');
@@ -78,7 +77,7 @@ function configureHubDbFetchCommand(program) {
     .version(version)
     .description('Fetch a HubDB table')
     .arguments('<tableId> <dest>')
-    .action(async (tableIdOrName, dest, command = {}) => {
+    .action(async (tableId, dest, command = {}) => {
       setLogLevel(command);
       logDebugInfo(command);
       const { config: configPath } = command;
@@ -90,8 +89,6 @@ function configureHubDbFetchCommand(program) {
       }
       const portalId = getPortalId(command);
       try {
-        const tableId = await getTableId(portalId, tableIdOrName);
-
         await downloadHubDbTable(
           portalId,
           tableId,

--- a/packages/cms-cli/commands/hubdb.js
+++ b/packages/cms-cli/commands/hubdb.js
@@ -30,7 +30,7 @@ function configureHubDbCommand(program) {
     .version(version)
     .description('Manage HubDB tables')
     .command('create <src>', 'create a HubDB table')
-    .command('fetch <tableId> <dest>', 'fetch a HubDB table');
+    .command('fetch <table> <dest>', 'fetch a HubDB table');
 
   addLoggerOptions(program);
   addHelpUsageTracking(program);
@@ -76,7 +76,7 @@ function configureHubDbFetchCommand(program) {
   program
     .version(version)
     .description('Fetch a HubDB table')
-    .arguments('<tableId> <dest>')
+    .arguments('<table> <dest>')
     .action(async (tableId, dest, command = {}) => {
       setLogLevel(command);
       logDebugInfo(command);

--- a/packages/cms-cli/commands/hubdb.js
+++ b/packages/cms-cli/commands/hubdb.js
@@ -10,6 +10,7 @@ const { getCwd } = require('@hubspot/cms-lib/path');
 const {
   createHubDbTable,
   downloadHubDbTable,
+  getTableId,
 } = require('@hubspot/cms-lib/hubdb');
 
 const { validatePortal } = require('../lib/validation');
@@ -77,7 +78,7 @@ function configureHubDbFetchCommand(program) {
     .version(version)
     .description('Fetch a HubDB table')
     .arguments('<tableId> <dest>')
-    .action(async (tableId, dest, command = {}) => {
+    .action(async (tableIdOrName, dest, command = {}) => {
       setLogLevel(command);
       logDebugInfo(command);
       const { config: configPath } = command;
@@ -89,6 +90,8 @@ function configureHubDbFetchCommand(program) {
       }
       const portalId = getPortalId(command);
       try {
+        const tableId = await getTableId(portalId, tableIdOrName);
+
         await downloadHubDbTable(
           portalId,
           tableId,

--- a/packages/cms-lib/api/hubdb.js
+++ b/packages/cms-lib/api/hubdb.js
@@ -1,6 +1,12 @@
 const http = require('../http');
 const HUBDB_API_PATH = 'hubdb/api/v2';
 
+async function fetchTablecCount(portalId) {
+  return http.get(portalId, {
+    uri: `${HUBDB_API_PATH}/tables/count`,
+  });
+}
+
 async function fetchTables(portalId) {
   return http.get(portalId, {
     uri: `${HUBDB_API_PATH}/tables`,
@@ -68,6 +74,7 @@ async function deleteRows(portalId, tableId, rowIds) {
 }
 
 module.exports = {
+  fetchTablecCount,
   createRows,
   createTable,
   updateTable,

--- a/packages/cms-lib/api/hubdb.js
+++ b/packages/cms-lib/api/hubdb.js
@@ -1,7 +1,7 @@
 const http = require('../http');
 const HUBDB_API_PATH = 'hubdb/api/v2';
 
-async function fetchTablecCount(portalId) {
+async function fetchTableCount(portalId) {
   return http.get(portalId, {
     uri: `${HUBDB_API_PATH}/tables/count`,
   });
@@ -74,7 +74,7 @@ async function deleteRows(portalId, tableId, rowIds) {
 }
 
 module.exports = {
-  fetchTablecCount,
+  fetchTableCount,
   createRows,
   createTable,
   updateTable,

--- a/packages/cms-lib/hubdb.js
+++ b/packages/cms-lib/hubdb.js
@@ -6,6 +6,8 @@ const {
   createTable,
   updateTable,
   createRows,
+  fetchTableCount,
+  fetchTables,
   fetchTable,
   fetchRows,
   publishTable,
@@ -27,6 +29,34 @@ function validateJsonFile(src) {
   }
 }
 
+async function getTableIdByName(portalId, tableName) {
+  let totalTables = await fetchTableCount(portalId);
+
+  let count = 0;
+  let offset = 0;
+
+  while (totalTables === null || count < totalTables) {
+    const response = await fetchTables(portalId, { offset });
+
+    count += response.objects.length;
+    offset += response.objects.length;
+
+    const findTable = response.objects.find(table => table.name === tableName);
+    if (findTable) {
+      return findTable.id;
+    }
+  }
+}
+
+async function getTableId(portalId, nameOrId) {
+  if (typeof nameOrId === 'number') {
+    return nameOrId;
+  } else if (/^\d+$/.test(nameOrId)) {
+    return parseInt(nameOrId, 10);
+  } else {
+    return getTableIdByName(portalId, nameOrId);
+  }
+}
 async function addRowsToHubDbTable(portalId, tableId, rows, columns) {
   const rowsToUpdate = rows.map(row => {
     const values = {};
@@ -191,4 +221,5 @@ module.exports = {
   clearHubDbTableRows,
   updateHubDbTable,
   addRowsToHubDbTable,
+  getTableId,
 };


### PR DESCRIPTION
Changes `<tableId>` to `<table`> . Looks up table by name unless a number (tableId) is passed as an arg.

Fixes #185 