### PR TITLE
Converting --qa flag "inheritance" for commands into separate commands entirely

### DIFF
--- a/packages/cms-cli/bin/hs-qa-auth.js
+++ b/packages/cms-cli/bin/hs-qa-auth.js
@@ -7,3 +7,7 @@ const { qaAuthCommand } = require('../commands/qa');
 const program = new Command('hs qa auth');
 qaAuthCommand(program);
 program.parse(process.argv);
+
+if (!process.argv.slice(2).length) {
+  program.help();
+}

--- a/packages/cms-cli/bin/hs-qa-auth.js
+++ b/packages/cms-cli/bin/hs-qa-auth.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+const { Command } = require('commander');
+
+const { qaAuthCommand } = require('../commands/qa');
+
+const program = new Command('hs qa auth');
+qaAuthCommand(program);
+program.parse(process.argv);

--- a/packages/cms-cli/bin/hs-qa-init.js
+++ b/packages/cms-cli/bin/hs-qa-init.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+const { Command } = require('commander');
+
+const { qaInitCommand } = require('../commands/qa');
+
+const program = new Command('hs qa init');
+qaInitCommand(program);
+program.parse(process.argv);

--- a/packages/cms-cli/bin/hs-qa.js
+++ b/packages/cms-cli/bin/hs-qa.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+const { Command } = require('commander');
+
+const { qaCommand } = require('../commands/qa');
+
+const program = new Command('hs qa');
+qaCommand(program);
+program.parse(process.argv);

--- a/packages/cms-cli/commands/auth.js
+++ b/packages/cms-cli/commands/auth.js
@@ -128,4 +128,5 @@ function configureAuthCommand(program) {
 
 module.exports = {
   configureAuthCommand,
+  authAction,
 };

--- a/packages/cms-cli/commands/auth.js
+++ b/packages/cms-cli/commands/auth.js
@@ -25,7 +25,6 @@ const {
   addConfigOptions,
   addLoggerOptions,
   setLogLevel,
-  addTestingOptions,
 } = require('../lib/commonOpts');
 const { logDebugInfo } = require('../lib/debugInfo');
 const {
@@ -122,7 +121,6 @@ function configureAuthCommand(program) {
 
   addLoggerOptions(program);
   addConfigOptions(program);
-  addTestingOptions(program);
   addHelpUsageTracking(program, COMMAND_NAME);
 }
 

--- a/packages/cms-cli/commands/init.js
+++ b/packages/cms-cli/commands/init.js
@@ -22,11 +22,7 @@ const {
   addHelpUsageTracking,
   trackAuthAction,
 } = require('../lib/usageTracking');
-const {
-  addLoggerOptions,
-  setLogLevel,
-  addTestingOptions,
-} = require('../lib/commonOpts');
+const { addLoggerOptions, setLogLevel } = require('../lib/commonOpts');
 const { promptUser, PORTAL_NAME } = require('../lib/prompts');
 const { logDebugInfo } = require('../lib/debugInfo');
 
@@ -104,7 +100,6 @@ function initializeConfigCommand(program) {
     .action(initAction);
 
   addLoggerOptions(program);
-  addTestingOptions(program);
   addHelpUsageTracking(program, COMMAND_NAME);
 }
 

--- a/packages/cms-cli/commands/main.js
+++ b/packages/cms-cli/commands/main.js
@@ -28,7 +28,10 @@ function configureMainCommand(program) {
     .command('remove <path>', 'delete a file or folder from HubSpot')
     .alias('rm')
     .command('secrets', 'manage HubSpot secrets')
-    .command('logs', 'get logs for a function');
+    .command('logs', 'get logs for a function')
+    .command('qa', 'run commands with configuration for QA environment', {
+      noHelp: true,
+    });
 
   addHelpUsageTracking(program);
 }

--- a/packages/cms-cli/commands/qa.js
+++ b/packages/cms-cli/commands/qa.js
@@ -1,0 +1,46 @@
+const { initializeConfigCommand } = require('../commands/init');
+const { configureAuthCommand } = require('../commands/auth');
+const { initAction } = require('./init');
+const { authAction } = require('./auth');
+const {
+  DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
+  ENVIRONMENTS,
+  SUPPORTED_AUTHENTICATION_PROTOCOLS_TEXT,
+} = require('@hubspot/cms-lib/lib/constants');
+
+function qaCommand(program) {
+  program
+    .description('Run commands with configuration for QA environment')
+    .command(
+      'init',
+      `initialize ${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME} for a HubSpot portal in ${ENVIRONMENTS.QA} environment`
+    )
+    .command(
+      'auth',
+      `Configure authentication for a HubSpot account in ${ENVIRONMENTS.QA} environment. Supported authentication protocols are ${SUPPORTED_AUTHENTICATION_PROTOCOLS_TEXT}.`
+    );
+}
+
+function qaInitCommand(program) {
+  program
+    .description('run commands with configuration for QA environment')
+    .action(async options => {
+      initializeConfigCommand(program);
+      initAction(options);
+    });
+}
+
+function qaAuthCommand(program) {
+  program
+    .description('run commands with configuration for QA environment')
+    .action(async options => {
+      configureAuthCommand(program);
+      authAction(options);
+    });
+}
+
+module.exports = {
+  qaCommand,
+  qaInitCommand,
+  qaAuthCommand,
+};

--- a/packages/cms-cli/commands/qa.js
+++ b/packages/cms-cli/commands/qa.js
@@ -1,5 +1,3 @@
-const { initializeConfigCommand } = require('../commands/init');
-const { configureAuthCommand } = require('../commands/auth');
 const { initAction } = require('./init');
 const { authAction } = require('./auth');
 const {
@@ -8,34 +6,34 @@ const {
   SUPPORTED_AUTHENTICATION_PROTOCOLS_TEXT,
 } = require('@hubspot/cms-lib/lib/constants');
 
+const initDescription = `Initialize ${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME} for a HubSpot portal in ${ENVIRONMENTS.QA} environment.`;
+const authDescription = `Configure authentication for a HubSpot account in ${ENVIRONMENTS.QA} environment. Supported authentication protocols are ${SUPPORTED_AUTHENTICATION_PROTOCOLS_TEXT}.`;
+
 function qaCommand(program) {
   program
     .description('Run commands with configuration for QA environment')
-    .command(
-      'init',
-      `initialize ${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME} for a HubSpot portal in ${ENVIRONMENTS.QA} environment`
-    )
-    .command(
-      'auth',
-      `Configure authentication for a HubSpot account in ${ENVIRONMENTS.QA} environment. Supported authentication protocols are ${SUPPORTED_AUTHENTICATION_PROTOCOLS_TEXT}.`
-    );
+    .command('init', initDescription)
+    .command('auth', authDescription);
 }
 
 function qaInitCommand(program) {
-  program
-    .description('run commands with configuration for QA environment')
-    .action(async options => {
-      initializeConfigCommand(program);
-      initAction(options);
+  program.description(initDescription).action(async options => {
+    initAction({
+      ...options,
+      qa: true,
     });
+  });
 }
 
 function qaAuthCommand(program) {
   program
-    .description('run commands with configuration for QA environment')
-    .action(async options => {
-      configureAuthCommand(program);
-      authAction(options);
+    .description(authDescription)
+    .arguments('<type>')
+    .action(async (type, options) => {
+      authAction(type, {
+        ...options,
+        qa: true,
+      });
     });
 }
 

--- a/packages/cms-cli/lib/commonOpts.js
+++ b/packages/cms-cli/lib/commonOpts.js
@@ -34,10 +34,6 @@ const addModeOptions = (program, { read, write }) => {
   program.option('--mode <mode>', help);
 };
 
-const addTestingOptions = program => {
-  program.option('--qa', 'run command in qa mode', false);
-};
-
 const setLogLevel = (options = {}) => {
   const { debug } = options;
   if (debug) {
@@ -86,7 +82,6 @@ module.exports = {
   addConfigOptions,
   addOverwriteOptions,
   addModeOptions,
-  addTestingOptions,
   setLogLevel,
   getPortalId,
   getMode,

--- a/packages/cms-lib/lib/constants.js
+++ b/packages/cms-lib/lib/constants.js
@@ -1,3 +1,5 @@
+const { commaSeparatedValues } = require('@hubspot/cms-cli/lib/text');
+
 const ENVIRONMENTS = {
   PROD: 'prod',
   QA: 'qa',
@@ -60,6 +62,11 @@ const AUTH_METHODS = {
   oauth: OAUTH_AUTH_METHOD,
 };
 
+const SUPPORTED_AUTHENTICATION_PROTOCOLS_TEXT = commaSeparatedValues([
+  OAUTH_AUTH_METHOD.value,
+  PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
+]);
+
 const DEFAULT_OAUTH_SCOPES = ['content'];
 
 const OAUTH_SCOPES = [
@@ -104,4 +111,6 @@ module.exports = {
   OAUTH_AUTH_METHOD,
   PERSONAL_ACCESS_KEY_AUTH_METHOD,
   ENVIRONMENT_VARIABLES,
+  // Text only
+  SUPPORTED_AUTHENTICATION_PROTOCOLS_TEXT,
 };


### PR DESCRIPTION
- Removes ability to dynamically add the `--qa` flag to commands
- Creates a `hs qa` command with subcommands that are used only for qa environment and not displayed in help output
  - `hs qa init`
  - `hs qa auth <type>`