### PR TITLE
Require dest arg in create command

### DIFF
--- a/packages/cms-cli/commands/create.js
+++ b/packages/cms-cli/commands/create.js
@@ -114,7 +114,12 @@ function configureCreateCommand(program) {
         dest = name;
       }
 
-      dest = resolveLocalPath(dest);
+      if (dest) {
+        dest = resolveLocalPath(dest);
+      } else {
+        logger.error(`Required argument 'dest' is missing.`);
+        return false;
+      }
 
       try {
         await fs.ensureDir(dest);


### PR DESCRIPTION
Makes the `dest` argument mandatory when running `hs create`. Previously this was enforced which caused inconsistent results like errors or output to the CWD.