### PR TITLE
Add default folder name for website-theme, function, react-app projects

### DIFF
--- a/packages/cms-cli/commands/create.js
+++ b/packages/cms-cli/commands/create.js
@@ -106,12 +106,16 @@ function configureCreateCommand(program) {
       }
 
       // TODO: In yargs use `.implies()`
-      if (
-        [TYPES['website-theme'], TYPES.function, TYPES['react-app']].includes(
-          type
-        )
-      ) {
-        dest = name || type;
+      switch (type) {
+        case TYPES.function:
+          dest = name;
+          break;
+        case TYPES['website-theme']:
+        case TYPES['react-app']:
+          dest = name || type;
+          break;
+        default:
+          break;
       }
 
       dest = resolveLocalPath(dest);

--- a/packages/cms-cli/commands/create.js
+++ b/packages/cms-cli/commands/create.js
@@ -111,7 +111,7 @@ function configureCreateCommand(program) {
           type
         )
       ) {
-        dest = name;
+        dest = name || type;
       }
 
       dest = resolveLocalPath(dest);


### PR DESCRIPTION
If a user doesn't include a `dest` when running `hs create` the existing behavior is to create the project in the CWD. However, this led to unexpected results with some project types. This change adds a default `dest`, which is the `type` of project.