### PR TITLE
Upgrade HubDB api to V3

### DIFF
--- a/packages/cms-lib/api/hubdb.js
+++ b/packages/cms-lib/api/hubdb.js
@@ -62,7 +62,7 @@ async function fetchRows(portalId, tableId, query = {}) {
 
 async function deleteRows(portalId, tableId, rowIds) {
   return http.post(portalId, {
-    uri: `${HUBDB_API_PATH}/tables/${tableId}/draft/batch/purge`,
+    uri: `${HUBDB_API_PATH}/tables/${tableId}/rows/draft/batch/purge`,
     body: rowIds,
   });
 }

--- a/packages/cms-lib/api/hubdb.js
+++ b/packages/cms-lib/api/hubdb.js
@@ -1,5 +1,5 @@
 const http = require('../http');
-const HUBDB_API_PATH = 'hubdb/api/v2';
+const HUBDB_API_PATH = '/cms/v3/hubdb';
 
 async function fetchTables(portalId) {
   return http.get(portalId, {
@@ -21,15 +21,15 @@ async function createTable(portalId, schema) {
 }
 
 async function updateTable(portalId, tableId, schema) {
-  return http.put(portalId, {
+  return http.patch(portalId, {
     uri: `${HUBDB_API_PATH}/tables/${tableId}`,
     body: schema,
   });
 }
 
 async function publishTable(portalId, tableId) {
-  return http.put(portalId, {
-    uri: `${HUBDB_API_PATH}/tables/${tableId}/publish`,
+  return http.post(portalId, {
+    uri: `${HUBDB_API_PATH}/tables/${tableId}/draft/push-live`,
   });
 }
 
@@ -41,14 +41,14 @@ async function deleteTable(portalId, tableId) {
 
 async function updateRows(portalId, tableId, rows) {
   return http.post(portalId, {
-    uri: `${HUBDB_API_PATH}/tables/${tableId}/rows/batch/update`,
+    uri: `${HUBDB_API_PATH}/tables/${tableId}/rows/draft/batch/update`,
     body: rows,
   });
 }
 
 async function createRows(portalId, tableId, rows) {
   return http.post(portalId, {
-    uri: `${HUBDB_API_PATH}/tables/${tableId}/rows/batch/create`,
+    uri: `${HUBDB_API_PATH}/tables/${tableId}/rows/draft/batch/create`,
     body: rows,
   });
 }
@@ -62,7 +62,7 @@ async function fetchRows(portalId, tableId, query = {}) {
 
 async function deleteRows(portalId, tableId, rowIds) {
   return http.post(portalId, {
-    uri: `${HUBDB_API_PATH}/tables/${tableId}/rows/batch/delete`,
+    uri: `${HUBDB_API_PATH}/tables/${tableId}/draft/batch/purge`,
     body: rowIds,
   });
 }

--- a/packages/cms-lib/hubdb.js
+++ b/packages/cms-lib/hubdb.js
@@ -153,9 +153,9 @@ async function downloadHubDbTable(portalId, tableId, dest) {
       totalRows = response.total;
     }
 
-    count += response.objects.length;
-    offset += response.objects.length;
-    rows = rows.concat(response.objects);
+    count += response.results.length;
+    offset += response.results.length;
+    rows = rows.concat(response.results);
   }
 
   const tableToWrite = JSON.stringify(convertToJSON(table, rows));
@@ -177,9 +177,9 @@ async function clearHubDbTableRows(portalId, tableId) {
       totalRows = response.total;
     }
 
-    count += response.objects.length;
-    offset += response.objects.length;
-    const rowIds = response.objects.map(row => row.id);
+    count += response.results.length;
+    offset += response.results.length;
+    const rowIds = response.results.map(row => row.id);
     rows = rows.concat(rowIds);
   }
   return deleteRows(portalId, tableId, rows);


### PR DESCRIPTION
Upgrade to the HubDB V3 Api, which supports working with tables by `name` or `ID`.

This is still WIP, methods and some response bodies change so I will still need to review/test all of the endpoints used.

Fixes #185 
Supersedes #203 