### PR TITLE
Improve/filemanager fetch

### DIFF
--- a/packages/cms-cli/commands/filemanager.js
+++ b/packages/cms-cli/commands/filemanager.js
@@ -27,6 +27,7 @@ const {
   addConfigOptions,
   addPortalOptions,
   addLoggerOptions,
+  addOverwriteOptions,
   setLogLevel,
   getPortalId,
 } = require('../lib/commonOpts');
@@ -85,6 +86,7 @@ function configureFileManagerFetchCommand(program) {
       downloadFileOrFolder(portalId, src, dest, program);
     });
 
+  addOverwriteOptions(program);
   addConfigOptions(program);
   addPortalOptions(program);
   addLoggerOptions(program);

--- a/packages/cms-lib/fileManager.js
+++ b/packages/cms-lib/fileManager.js
@@ -44,12 +44,24 @@ async function uploadFolder(portalId, src, dest, { cwd }) {
     const file = filesToUpload[index];
     const relativePath = file.replace(regex, '');
     const destPath = convertToUnixPath(path.join(dest, relativePath));
-    logger.debug('Attempting to upload file "%s" to "%s"', file, destPath);
+    logger.debug(
+      'Attempting to upload file "%s" to file manager path "%s"',
+      file,
+      destPath
+    );
     try {
       await uploadFile(portalId, file, destPath);
-      logger.log('Uploaded file "%s" to "%s"', file, destPath);
+      logger.log(
+        'Uploaded file "%s" to file manager path "%s"',
+        file,
+        destPath
+      );
     } catch (error) {
-      logger.error('Uploading file "%s" to "%s" failed', file, destPath);
+      logger.error(
+        'Uploading file "%s" to file manager path "%s" failed',
+        file,
+        destPath
+      );
       if (isFatalError(error)) {
         throw error;
       }
@@ -166,7 +178,6 @@ async function getAllPagedFiles(portalId, folderPath) {
  */
 async function fetchFolderContents(portalId, folder, dest, options) {
   const files = await getAllPagedFiles(portalId, folder.full_path);
-
   for (const file of files) {
     await downloadFile(portalId, file, dest, options);
   }
@@ -193,8 +204,12 @@ async function downloadFileOrFolder(portalId, src, dest, options) {
   const { file, folder } = await getStat(portalId, src);
   if (file) {
     try {
-      await downloadFile(portalId, file, dest);
-      logger.log(`File ${src} was downloaded to ${dest}`);
+      await downloadFile(portalId, file, dest, options);
+      logger.log(
+        'Completed fetch of file manager file "%s" to "%s"',
+        src,
+        dest
+      );
     } catch (err) {
       logErrorInstance(err);
     }
@@ -205,9 +220,17 @@ async function downloadFileOrFolder(portalId, src, dest, options) {
           ? convertToLocalFileSystemPath(path.resolve(dest, folder.name))
           : dest;
       await fetchFolderContents(portalId, folder, rootPath, options);
-      logger.log('Completed fetch of folder "%s" to "%s"', src, dest);
+      logger.log(
+        'Completed fetch of file manager folder "%s" to "%s"',
+        src,
+        dest
+      );
     } catch (err) {
-      logger.error('Failed fetch of folder "%s" to "%s"', src, dest);
+      logger.error(
+        'Failed fetch of file manager folder "%s" to "%s"',
+        src,
+        dest
+      );
     }
   }
 }

--- a/packages/cms-lib/fileManager.js
+++ b/packages/cms-lib/fileManager.js
@@ -100,6 +100,7 @@ async function downloadFile(portalId, file, dest, folderPath) {
       },
       writeStream
     );
+    logger.log(`Wrote file "${destPath}"`);
   } catch (err) {
     logErrorInstance(err);
   }
@@ -160,9 +161,8 @@ async function downloadFileOrFolder(portalId, remotePath, localDest) {
   const { file, folder } = await getStat(portalId, remotePath);
 
   if (file) {
-    const folderPath = path.dirname(remotePath);
     try {
-      await downloadFile(portalId, file, localDest, folderPath);
+      await downloadFile(portalId, file, localDest, '');
       logger.log(`File ${remotePath} was downloaded to ${localDest}`);
     } catch (err) {
       logErrorInstance(err);

--- a/packages/cms-lib/fileManager.js
+++ b/packages/cms-lib/fileManager.js
@@ -180,8 +180,8 @@ async function fetchFolderContents(portalId, folder, dest, options) {
     folder.full_path
   );
   for (const folder of folders) {
-    const subFolder = path.join(dest, folder.name);
-    await fetchFolderContents(portalId, folder, subFolder, options);
+    const nestedFolder = path.join(dest, folder.name);
+    await fetchFolderContents(portalId, folder, nestedFolder, options);
   }
 }
 

--- a/packages/cms-lib/fileManager.js
+++ b/packages/cms-lib/fileManager.js
@@ -205,7 +205,7 @@ async function downloadFileOrFolder(portalId, src, dest, options) {
     try {
       await downloadFile(portalId, file, dest, options);
       logger.success(
-        'Fetch of file "%s" to "%s" in the File Manager is complete',
+        'Completed fetch of file "%s" to "%s" from the File Manager',
         src,
         dest
       );
@@ -226,7 +226,7 @@ async function downloadFileOrFolder(portalId, src, dest, options) {
           : dest;
       await fetchFolderContents(portalId, folder, rootPath, options);
       logger.success(
-        'Fetch of folder "%s" to "%s" in the File Manager is complete',
+        'Completed fetch of folder "%s" to "%s" from the File Manager',
         src,
         dest
       );

--- a/packages/cms-lib/fileManager.js
+++ b/packages/cms-lib/fileManager.js
@@ -45,23 +45,16 @@ async function uploadFolder(portalId, src, dest, { cwd }) {
     const relativePath = file.replace(regex, '');
     const destPath = convertToUnixPath(path.join(dest, relativePath));
     logger.debug(
-      'Attempting to upload file "%s" to file manager path "%s"',
+      'Uploading files from "%s" to "%s" in the File Manager of portal %s',
       file,
-      destPath
+      destPath,
+      portalId
     );
     try {
       await uploadFile(portalId, file, destPath);
-      logger.log(
-        'Uploaded file "%s" to file manager path "%s"',
-        file,
-        destPath
-      );
+      logger.log('Uploaded file "%s" to "%s"', file, destPath);
     } catch (error) {
-      logger.error(
-        'Uploading file "%s" to file manager path "%s" failed',
-        file,
-        destPath
-      );
+      logger.error('Uploading file "%s" to "%s" failed', file, destPath);
       if (isFatalError(error)) {
         throw error;
       }
@@ -203,10 +196,16 @@ async function fetchFolderContents(portalId, folder, dest, options) {
 async function downloadFileOrFolder(portalId, src, dest, options) {
   const { file, folder } = await getStat(portalId, src);
   if (file) {
+    logger.log(
+      'Fetching file from "%s" to "%s" in the File Manager of portal %s',
+      src,
+      dest,
+      portalId
+    );
     try {
       await downloadFile(portalId, file, dest, options);
-      logger.log(
-        'Completed fetch of file manager file "%s" to "%s"',
+      logger.success(
+        'Fetch of file "%s" to "%s" in the File Manager is complete',
         src,
         dest
       );
@@ -214,23 +213,25 @@ async function downloadFileOrFolder(portalId, src, dest, options) {
       logErrorInstance(err);
     }
   } else if (folder) {
+    logger.log(
+      'Fetching files from "%s" to "%s" in the File Manager of portal %s',
+      src,
+      dest,
+      portalId
+    );
     try {
       const rootPath =
         dest === getCwd()
           ? convertToLocalFileSystemPath(path.resolve(dest, folder.name))
           : dest;
       await fetchFolderContents(portalId, folder, rootPath, options);
-      logger.log(
-        'Completed fetch of file manager folder "%s" to "%s"',
+      logger.success(
+        'Fetch of folder "%s" to "%s" in the File Manager is complete',
         src,
         dest
       );
     } catch (err) {
-      logger.error(
-        'Failed fetch of file manager folder "%s" to "%s"',
-        src,
-        dest
-      );
+      logger.error('Failed fetch of folder "%s" to "%s"', src, dest);
     }
   }
 }


### PR DESCRIPTION
Addresses https://github.com/HubSpot/hubspot-cms-tools/pull/215#issuecomment-638861924
Fixes #220
Fixes #214 

- Existing files will be skipped, unless `--overwite` is passed
- Directory logic now matches `hs fetch`:
  - If no `dest` is passed, the folder will be created
  - If `dest` is passed, files will be written inside that folder
- Logging is updated to match `hs fetch`