### PR TITLE
Allow fetching of all FM files

### DIFF
--- a/packages/cms-cli/commands/filemanager.js
+++ b/packages/cms-cli/commands/filemanager.js
@@ -59,7 +59,10 @@ function configureFileManagerFetchCommand(program) {
       'Download a folder or file from the HubSpot File Manager to your computer'
     )
     .arguments('<src> [dest]')
-    .option('--include-archived', 'Inlude archived files')
+    .option(
+      '--include-archived',
+      'Include files that have been marked as "archived"'
+    )
     .action(async (src, dest) => {
       setLogLevel(program);
       logDebugInfo(program);

--- a/packages/cms-cli/commands/filemanager.js
+++ b/packages/cms-cli/commands/filemanager.js
@@ -59,6 +59,7 @@ function configureFileManagerFetchCommand(program) {
       'Download a folder or file from the HubSpot File Manager to your computer'
     )
     .arguments('<src> [dest]')
+    .option('--include-archived', 'Inlude archived files')
     .action(async (src, dest) => {
       setLogLevel(program);
       logDebugInfo(program);

--- a/packages/cms-lib/api/fileManager.js
+++ b/packages/cms-lib/api/fileManager.js
@@ -25,13 +25,13 @@ async function uploadFile(portalId, src, dest) {
   });
 }
 
-async function getStat(portalId, src) {
+async function fetchStat(portalId, src) {
   return http.get(portalId, {
     uri: `${FILE_MANAGER_API_PATH}/files/stat/${src}`,
   });
 }
 
-async function getFiles(portalId, folderId, { offset, archived }) {
+async function fetchFiles(portalId, folderId, { offset, archived }) {
   return http.get(portalId, {
     uri: `${FILE_MANAGER_API_PATH}/files/`,
     qs: {
@@ -43,7 +43,7 @@ async function getFiles(portalId, folderId, { offset, archived }) {
   });
 }
 
-async function getFolders(portalId, folderId) {
+async function fetchFolders(portalId, folderId) {
   return http.get(portalId, {
     uri: `${FILE_MANAGER_API_PATH}/folders/`,
     qs: {
@@ -55,7 +55,7 @@ async function getFolders(portalId, folderId) {
 
 module.exports = {
   uploadFile,
-  getStat,
-  getFiles,
-  getFolders,
+  fetchStat,
+  fetchFiles,
+  fetchFolders,
 };

--- a/packages/cms-lib/api/fileManager.js
+++ b/packages/cms-lib/api/fileManager.js
@@ -38,7 +38,7 @@ async function fetchFiles(portalId, folderId, { offset, archived }) {
       hidden: 0,
       offset: offset,
       folder_id: folderId || 'None',
-      ...(archived === 0 && { archived }),
+      ...(!archived && { archived: 0 }),
     },
   });
 }

--- a/packages/cms-lib/api/fileManager.js
+++ b/packages/cms-lib/api/fileManager.js
@@ -31,14 +31,14 @@ async function getStat(portalId, src) {
   });
 }
 
-async function getFiles(portalId, folderId, { offset }, showArchived) {
+async function getFiles(portalId, folderId, { offset, archived }) {
   return http.get(portalId, {
     uri: `${FILE_MANAGER_API_PATH}/files/`,
     qs: {
       hidden: 0,
       offset: offset,
       folder_id: folderId || 'None',
-      ...(!showArchived && { archived: 0 }),
+      ...(archived === 0 && { archived }),
     },
   });
 }

--- a/packages/cms-lib/api/fileManager.js
+++ b/packages/cms-lib/api/fileManager.js
@@ -31,13 +31,14 @@ async function getStat(portalId, src) {
   });
 }
 
-async function getFiles(portalId, folderId) {
+async function getFiles(portalId, folderId, { offset }, showArchived) {
   return http.get(portalId, {
     uri: `${FILE_MANAGER_API_PATH}/files/`,
     qs: {
       hidden: 0,
-      archived: 0,
+      offset: offset,
       folder_id: folderId || 'None',
+      ...(!showArchived && { archived: 0 }),
     },
   });
 }
@@ -47,7 +48,6 @@ async function getFolders(portalId, folderId) {
     uri: `${FILE_MANAGER_API_PATH}/folders/`,
     qs: {
       hidden: 0,
-      archived: 0,
       parent_folder_id: folderId || 'None',
     },
   });

--- a/packages/cms-lib/api/fileManager.js
+++ b/packages/cms-lib/api/fileManager.js
@@ -31,21 +31,31 @@ async function getStat(portalId, src) {
   });
 }
 
-async function getFilesByPath(portalId, src) {
+async function getFiles(portalId, folderId) {
   return http.get(portalId, {
-    uri: `${FILE_MANAGER_API_PATH}/files/path/${src}`,
+    uri: `${FILE_MANAGER_API_PATH}/files/`,
+    qs: {
+      hidden: 0,
+      archived: 0,
+      folder_id: folderId || 'None',
+    },
   });
 }
 
-async function getFoldersByPath(portalId, src) {
+async function getFolders(portalId, folderId) {
   return http.get(portalId, {
-    uri: `${FILE_MANAGER_API_PATH}/folders/path/${src}`,
+    uri: `${FILE_MANAGER_API_PATH}/folders/`,
+    qs: {
+      hidden: 0,
+      archived: 0,
+      parent_folder_id: folderId || 'None',
+    },
   });
 }
 
 module.exports = {
   uploadFile,
   getStat,
-  getFilesByPath,
-  getFoldersByPath,
+  getFiles,
+  getFolders,
 };

--- a/packages/cms-lib/fileManager.js
+++ b/packages/cms-lib/fileManager.js
@@ -90,6 +90,14 @@ async function skipExisting(overwrite, filepath) {
 }
 
 /**
+ * @private
+ * @param {object} file
+ */
+function isHidden(node) {
+  return node.hidden || node.deleted;
+}
+
+/**
  *
  * @param {number} portalId
  * @param {object} file
@@ -97,6 +105,10 @@ async function skipExisting(overwrite, filepath) {
  * @param {object} options
  */
 async function downloadFile(portalId, file, dest, options) {
+  if (isHidden(file)) {
+    return;
+  }
+
   const fileName = `${file.name}.${file.extension}`;
   const destPath = convertToLocalFileSystemPath(path.join(dest, fileName));
 
@@ -171,6 +183,9 @@ async function getAllPagedFiles(portalId, folderPath) {
  * @param {object} options
  */
 async function fetchFolderContents(portalId, folder, dest, options) {
+  if (isHidden(folder)) {
+    return;
+  }
   const files = await getAllPagedFiles(portalId, folder.full_path);
   for (const file of files) {
     await downloadFile(portalId, file, dest, options);
@@ -196,6 +211,10 @@ async function fetchFolderContents(portalId, folder, dest, options) {
  * @param {object} options
  */
 async function downloadFolder(portalId, src, dest, folder, options) {
+  if (isHidden(folder)) {
+    logger.error('Folder "%s" could not be found in portal %s', src, portalId);
+    return;
+  }
   try {
     const rootPath =
       dest === getCwd()
@@ -228,6 +247,10 @@ async function downloadFolder(portalId, src, dest, folder, options) {
  * @param {object} options
  */
 async function downloadSingleFile(portalId, src, dest, file, options) {
+  if (isHidden(file)) {
+    logger.error('File "%s" could not be found in portal %s', src, portalId);
+    return;
+  }
   try {
     logger.log(
       'Fetching file from "%s" to "%s" in the File Manager of portal %s',

--- a/packages/cms-lib/fileManager.js
+++ b/packages/cms-lib/fileManager.js
@@ -144,13 +144,18 @@ async function downloadFile(portalId, file, dest, options) {
  * @param {number} portalId
  * @param {string} folderPath
  */
-async function getAllPagedFiles(portalId, folderId) {
+async function getAllPagedFiles(portalId, folderId, { includeArchived }) {
   let totalFiles = null;
   let files = [];
   let count = 0;
   let offset = 0;
   while (totalFiles === null || count < totalFiles) {
-    const response = await getFiles(portalId, folderId, { offset });
+    const response = await getFiles(
+      portalId,
+      folderId,
+      { offset },
+      includeArchived
+    );
 
     if (totalFiles === null) {
       totalFiles = response.total;
@@ -171,7 +176,7 @@ async function getAllPagedFiles(portalId, folderId) {
  * @param {object} options
  */
 async function fetchFolderContents(portalId, folder, dest, options) {
-  const files = await getAllPagedFiles(portalId, folder.id);
+  const files = await getAllPagedFiles(portalId, folder.id, options);
   for (const file of files) {
     await downloadFile(portalId, file, dest, options);
   }
@@ -225,8 +230,11 @@ async function downloadFolder(portalId, src, dest, folder, options) {
  * @param {object} options
  */
 async function downloadSingleFile(portalId, src, dest, file, options) {
-  if (!file.archived) {
-    logger.error('File "%s" in the File Manager is archived', src);
+  if (file.archived) {
+    logger.error(
+      '"%s" in the File Manager is an archived file. Try fetching again with the "--inclulde-archived" flag.',
+      src
+    );
     return;
   }
 

--- a/packages/cms-lib/fileManager.js
+++ b/packages/cms-lib/fileManager.js
@@ -194,45 +194,51 @@ async function fetchFolderContents(portalId, folder, dest, options) {
  * @param {object} options
  */
 async function downloadFileOrFolder(portalId, src, dest, options) {
-  const { file, folder } = await getStat(portalId, src);
-  if (file) {
-    logger.log(
-      'Fetching file from "%s" to "%s" in the File Manager of portal %s',
-      src,
-      dest,
-      portalId
-    );
-    try {
+  let file, folder;
+
+  if (src === '/') {
+    folder = {
+      full_path: '',
+      name: '',
+    };
+  } else {
+    ({ file, folder } = await getStat(portalId, src));
+  }
+
+  try {
+    if (file) {
+      logger.log(
+        'Fetching file from "%s" to "%s" in the File Manager of portal %s',
+        src,
+        dest,
+        portalId
+      );
       await downloadFile(portalId, file, dest, options);
       logger.success(
         'Completed fetch of file "%s" to "%s" from the File Manager',
         src,
         dest
       );
-    } catch (err) {
-      logErrorInstance(err);
-    }
-  } else if (folder) {
-    logger.log(
-      'Fetching files from "%s" to "%s" in the File Manager of portal %s',
-      src,
-      dest,
-      portalId
-    );
-    try {
+    } else if (folder) {
       const rootPath =
         dest === getCwd()
           ? convertToLocalFileSystemPath(path.resolve(dest, folder.name))
           : dest;
+      logger.log(
+        'Fetching folder from "%s" to "%s" in the File Manager of portal %s',
+        src,
+        rootPath,
+        portalId
+      );
       await fetchFolderContents(portalId, folder, rootPath, options);
       logger.success(
         'Completed fetch of folder "%s" to "%s" from the File Manager',
         src,
         dest
       );
-    } catch (err) {
-      logger.error('Failed fetch of folder "%s" to "%s"', src, dest);
     }
+  } catch (err) {
+    logErrorInstance(err);
   }
 }
 

--- a/packages/cms-lib/fileManager.js
+++ b/packages/cms-lib/fileManager.js
@@ -237,6 +237,10 @@ async function downloadSingleFile(portalId, src, dest, file, options) {
     );
     return;
   }
+  if (file.hidden) {
+    logger.error('"%s" in the File Manager is a hidden file.', src);
+    return;
+  }
 
   try {
     logger.log(

--- a/packages/cms-lib/fileManager.js
+++ b/packages/cms-lib/fileManager.js
@@ -228,7 +228,7 @@ async function downloadFolder(portalId, src, dest, folder, options) {
  * @param {object} options
  */
 async function downloadSingleFile(portalId, src, dest, file, options) {
-  if (file.archived) {
+  if (!options.includeArchived && file.archived) {
     logger.error(
       '"%s" in the File Manager is an archived file. Try fetching again with the "--inclulde-archived" flag.',
       src

--- a/packages/cms-lib/fileManager.js
+++ b/packages/cms-lib/fileManager.js
@@ -150,12 +150,10 @@ async function getAllPagedFiles(portalId, folderId, { includeArchived }) {
   let count = 0;
   let offset = 0;
   while (totalFiles === null || count < totalFiles) {
-    const response = await getFiles(
-      portalId,
-      folderId,
-      { offset },
-      includeArchived
-    );
+    const response = await getFiles(portalId, folderId, {
+      offset,
+      archived: includeArchived ? 1 : 0,
+    });
 
     if (totalFiles === null) {
       totalFiles = response.total;

--- a/packages/cms-lib/fileManager.js
+++ b/packages/cms-lib/fileManager.js
@@ -230,7 +230,7 @@ async function downloadFolder(portalId, src, dest, folder, options) {
 async function downloadSingleFile(portalId, src, dest, file, options) {
   if (!options.includeArchived && file.archived) {
     logger.error(
-      '"%s" in the File Manager is an archived file. Try fetching again with the "--inclulde-archived" flag.',
+      '"%s" in the File Manager is an archived file. Try fetching again with the "--include-archived" flag.',
       src
     );
     return;

--- a/packages/cms-lib/fileManager.js
+++ b/packages/cms-lib/fileManager.js
@@ -90,14 +90,6 @@ async function skipExisting(overwrite, filepath) {
 }
 
 /**
- * @private
- * @param {object} file
- */
-function isHidden(node) {
-  return node.hidden || node.deleted;
-}
-
-/**
  *
  * @param {number} portalId
  * @param {object} file
@@ -105,10 +97,6 @@ function isHidden(node) {
  * @param {object} options
  */
 async function downloadFile(portalId, file, dest, options) {
-  if (isHidden(file)) {
-    return;
-  }
-
   const fileName = `${file.name}.${file.extension}`;
   const destPath = convertToLocalFileSystemPath(path.join(dest, fileName));
 
@@ -183,9 +171,6 @@ async function getAllPagedFiles(portalId, folderPath) {
  * @param {object} options
  */
 async function fetchFolderContents(portalId, folder, dest, options) {
-  if (isHidden(folder)) {
-    return;
-  }
   const files = await getAllPagedFiles(portalId, folder.full_path);
   for (const file of files) {
     await downloadFile(portalId, file, dest, options);
@@ -211,10 +196,6 @@ async function fetchFolderContents(portalId, folder, dest, options) {
  * @param {object} options
  */
 async function downloadFolder(portalId, src, dest, folder, options) {
-  if (isHidden(folder)) {
-    logger.error('Folder "%s" could not be found in portal %s', src, portalId);
-    return;
-  }
   try {
     const rootPath =
       dest === getCwd()
@@ -247,10 +228,6 @@ async function downloadFolder(portalId, src, dest, folder, options) {
  * @param {object} options
  */
 async function downloadSingleFile(portalId, src, dest, file, options) {
-  if (isHidden(file)) {
-    logger.error('File "%s" could not be found in portal %s', src, portalId);
-    return;
-  }
   try {
     logger.log(
       'Fetching file from "%s" to "%s" in the File Manager of portal %s',

--- a/packages/cms-lib/fileManager.js
+++ b/packages/cms-lib/fileManager.js
@@ -152,7 +152,7 @@ async function fetchAllPagedFiles(portalId, folderId, { includeArchived }) {
   while (totalFiles === null || count < totalFiles) {
     const response = await fetchFiles(portalId, folderId, {
       offset,
-      archived: includeArchived ? 1 : 0,
+      archived: includeArchived,
     });
 
     if (totalFiles === null) {


### PR DESCRIPTION
Fixes #234 

If `/` is passed as a `src` arg in `filemanager fetch`, the entire file manager will be downloaded

This also explicitly filters out hidden files and, optionally, archived files.

cc @ajlaporte 