### PR TITLE
Auth command uses personalaccesskey as the default if no argument is provided

### DIFF
--- a/packages/cms-cli/bin/hs-auth.js
+++ b/packages/cms-cli/bin/hs-auth.js
@@ -7,7 +7,3 @@ const { configureAuthCommand } = require('../commands/auth');
 const program = new Command('hs auth');
 configureAuthCommand(program);
 program.parse(process.argv);
-
-if (!process.argv.slice(2).length) {
-  program.help();
-}

--- a/packages/cms-cli/bin/hscms-auth.js
+++ b/packages/cms-cli/bin/hscms-auth.js
@@ -7,7 +7,3 @@ const { configureAuthCommand } = require('../commands/auth');
 const program = new Command('hscms auth');
 configureAuthCommand(program);
 program.parse(process.argv);
-
-if (!process.argv.slice(2).length) {
-  program.help();
-}

--- a/packages/cms-cli/commands/auth.js
+++ b/packages/cms-cli/commands/auth.js
@@ -49,7 +49,8 @@ const SUPPORTED_AUTHENTICATION_PROTOCOLS_TEXT = commaSeparatedValues(
 );
 
 async function authAction(type, options) {
-  const authType = type.toLowerCase();
+  const authType =
+    (type && type.toLowerCase()) || PERSONAL_ACCESS_KEY_AUTH_METHOD.value;
   setLogLevel(options);
   logDebugInfo(options);
   const { config: configPath } = options;
@@ -121,7 +122,7 @@ function configureAuthCommand(program) {
     .description(
       `Configure authentication for a HubSpot account. Supported authentication protocols are ${SUPPORTED_AUTHENTICATION_PROTOCOLS_TEXT}.`
     )
-    .arguments('<type>')
+    .arguments('[type]')
     .action(authAction);
 
   addLoggerOptions(program);


### PR DESCRIPTION
Fixes #153 

/cc @williamspiro 