### PR TITLE
Improve log messages to make debugging easier

### DIFF
--- a/packages/cms-cli/commands/init.js
+++ b/packages/cms-cli/commands/init.js
@@ -83,11 +83,13 @@ function initializeConfigCommand(program) {
           true
         );
 
+        const path = getConfigPath();
+        const portalId = getPortalId();
+
         logger.success(
-          `${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME} created with ${PERSONAL_ACCESS_KEY_AUTH_METHOD.name}.`
+          `The config file "${path}" was created using your personal access key for portal ${portalId}.`
         );
 
-        const portalId = getPortalId();
         trackAuthAction(
           COMMAND_NAME,
           PERSONAL_ACCESS_KEY_AUTH_METHOD.value,

--- a/packages/cms-lib/__tests__/errorHandlers.js
+++ b/packages/cms-lib/__tests__/errorHandlers.js
@@ -13,6 +13,12 @@ function createApiError(statusCode, method) {
     options: Object.freeze({
       method,
     }),
+    response: {
+      request: {
+        href: 'http://example.com/',
+        method: 'GET',
+      },
+    },
     message: `TEST ${method} ${statusCode}`,
   });
 }

--- a/packages/cms-lib/errorHandlers.js
+++ b/packages/cms-lib/errorHandlers.js
@@ -77,7 +77,19 @@ class FileSystemErrorContext extends ErrorContext {
  * @param {ErrorContext} context
  */
 function debugErrorAndContext(error, context) {
-  logger.debug('Error: %o', error);
+  if (error.name === 'StatusCodeError') {
+    const { statusCode, message, response } = error;
+    logger.debug('Error: %o', {
+      statusCode,
+      message,
+      url: response.request.href,
+      method: response.request.method,
+      response: response.body,
+      headers: response.headers,
+    });
+  } else {
+    logger.debug('Error: %o', error);
+  }
   logger.debug('Context: %o', context);
 }
 

--- a/packages/cms-lib/lib/config.js
+++ b/packages/cms-lib/lib/config.js
@@ -292,6 +292,10 @@ const loadConfigFromFile = (path, options = {}) => {
       logger.error(
         `A ${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME} file could not be found`
       );
+    } else {
+      logger.debug(
+        `A ${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME} file could not be found`
+      );
     }
     return;
   }
@@ -635,6 +639,11 @@ const loadEnvironmentVariableConfig = () => {
   if (!envConfig) {
     return;
   }
+  const { portalId } = getConfigVariablesFromEnv();
+
+  logger.debug(
+    `Loaded config from enviroment variables for portal ${portalId}`
+  );
 
   return setConfig(envConfig);
 };


### PR DESCRIPTION
This PR makes the following improvements to messaging:

1. Uses full path and portalId in the success message for the init command after the config file is created.
2. Outputs most relevant information for HTTP requests when they fail
3. Outputs info when the CLI is leveraging environment variables for the config instead of a file