### PR TITLE
Fix `hs watch . my-website-theme`

### DIFF
--- a/packages/cms-lib/__tests__/ignoreRules.js
+++ b/packages/cms-lib/__tests__/ignoreRules.js
@@ -42,5 +42,9 @@ describe('ignoreRules', () => {
     it('does not ignore allowed files', () => {
       expect(shouldIgnoreFile(`${REPO_FOLDER}/hiddenFile.js`, CWD)).toBe(false);
     });
+
+    it('does not ignore the current folder', () => {
+      expect(shouldIgnoreFile('', '')).toBe(false);
+    });
   });
 });

--- a/packages/cms-lib/__tests__/ignoreRules.js
+++ b/packages/cms-lib/__tests__/ignoreRules.js
@@ -44,7 +44,7 @@ describe('ignoreRules', () => {
     });
 
     it('does not ignore the current folder', () => {
-      expect(shouldIgnoreFile('', '')).toBe(false);
+      expect(shouldIgnoreFile(CWD, CWD)).toBe(false);
     });
   });
 });

--- a/packages/cms-lib/__tests__/ignoreRules.js
+++ b/packages/cms-lib/__tests__/ignoreRules.js
@@ -44,7 +44,7 @@ describe('ignoreRules', () => {
     });
 
     it('does not ignore the current folder', () => {
-      expect(shouldIgnoreFile(CWD, CWD)).toBe(false);
+      expect(shouldIgnoreFile('.', process.cwd())).toBe(false);
     });
   });
 });

--- a/packages/cms-lib/ignoreRules.js
+++ b/packages/cms-lib/ignoreRules.js
@@ -46,7 +46,8 @@ function loadIgnoreConfig() {
 function shouldIgnoreFile(file, cwd) {
   loadIgnoreConfig();
   const relativeTo = configPath || cwd;
-  return ignoreRules.ignores(path.relative(relativeTo, file));
+  const relativePath = path.relative(relativeTo, file);
+  return !!relativePath && ignoreRules.ignores(relativePath);
 }
 
 function createIgnoreFilter(cwd) {


### PR DESCRIPTION
# Steps to Reproduce
Given I run `hs watch . my-website-theme`
Then I errorneously get this output:

```
➜  my-website-theme hs watch . my-website-theme
(node:28185) UnhandledPromiseRejectionWarning: TypeError: path must not be empty
    at throwError (/usr/local/lib/node_modules/@hubspot/cms-cli/node_modules/ignore/index.js:366:9)
    at checkPath (/usr/local/lib/node_modules/@hubspot/cms-cli/node_modules/ignore/index.js:379:12)
    at Ignore._test (/usr/local/lib/node_modules/@hubspot/cms-cli/node_modules/ignore/index.js:502:5)
    at Ignore.ignores (/usr/local/lib/node_modules/@hubspot/cms-cli/node_modules/ignore/index.js:541:17)
    at shouldIgnoreFile (/usr/local/lib/node_modules/@hubspot/cms-cli/node_modules/@hubspot/cms-lib/ignoreRules.js:49:22)
    at ignored (/usr/local/lib/node_modules/@hubspot/cms-cli/node_modules/@hubspot/cms-lib/lib/watch.js:101:22)
    at matchPatterns (/usr/local/lib/node_modules/@hubspot/cms-cli/node_modules/anymatch/index.js:62:18)
    at FSWatcher._userIgnored (/usr/local/lib/node_modules/@hubspot/cms-cli/node_modules/anymatch/index.js:94:14)
    at FSWatcher._isIgnored (/usr/local/lib/node_modules/@hubspot/cms-cli/node_modules/chokidar/index.js:763:15)
    at FsEventsHandler._addToFsEvents (/usr/local/lib/node_modules/@hubspot/cms-cli/node_modules/chokidar/lib/fsevents-handler.js:459:18)
(node:28185) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:28185) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

Yet I'd expect it to upload local changes

# Severity
I like to have my `hubspot.config.yml` and my console in the synced folder, so that I end up running exactly the given command. It would be sad having to deepen my directory structure just to mitigate this bug.

# Analysis

* The exception we see comes from the `ignore` package [here](https://github.com/kaelzhang/node-ignore/blob/55ecc53f23e4ba787fce051a2bcd9d863aacc1f6/index.js#L379).
* Ignore intentionally complains when checking the empty path on it.
* It asks for anything that comes out of `path.relative(…)`
* Yet `path.relative('.','.')` returns an empty string
* I guess the best way out is to not involve `ignore` when `chokidar` let's us check the local folder. That'd be weird to ignore it all anyway…

# Todo

* [x] fix it
* [x] run test
* [x] run linter
* [x] try manually locally if `hs watch . my-website-theme` works well
* I'm unsure about what's left in your process here…