### PR TITLE
Allow user to functions in the same directory

### DIFF
--- a/packages/cms-lib/functions.js
+++ b/packages/cms-lib/functions.js
@@ -99,14 +99,16 @@ function createFunction(
   { functionsFolder, filename, endpointPath, endpointMethod },
   dest
 ) {
-  const ancestorFunctionsDir = findup('serverless.json', {
+  const ancestorFunctionsConfig = findup('serverless.json', {
     cwd: getCwd(),
     nocase: true,
   });
 
-  if (ancestorFunctionsDir) {
+  if (ancestorFunctionsConfig) {
     logger.error(
-      `Cannot create a functions directory inside "${ancestorFunctionsDir}"`
+      `Cannot create a functions directory inside "${path.dirname(
+        ancestorFunctionsConfig
+      )}"`
     );
     return;
   }

--- a/packages/cms-lib/functions.js
+++ b/packages/cms-lib/functions.js
@@ -4,6 +4,7 @@ const findup = require('findup-sync');
 const { logger } = require('./logger');
 const { logFileSystemErrorInstance } = require('./errorHandlers');
 const isObject = require('./lib/isObject');
+const { getCwd } = require('./path');
 
 const functionBody = `
 exports.main = ({ accountId, body, params }, sendResponse) => {
@@ -98,7 +99,10 @@ function createFunction(
   { functionsFolder, filename, endpointPath, endpointMethod },
   dest
 ) {
-  const ancestorFunctionsDir = findup('*.functions');
+  const ancestorFunctionsDir = findup('serverless.json', {
+    cwd: getCwd(),
+    nocase: true,
+  });
 
   if (ancestorFunctionsDir) {
     logger.error(


### PR DESCRIPTION
Instead of looking for ancestral `*.function` directories (which wasn't working) this switches to looking for `serverless.json` config files

@gcorne I see that you assigned that issue to yourself, if you have another idea for this in mind let me know