### PR TITLE
Start migrating to `yargs` via the remove subcommand

### DIFF
--- a/packages/cms-cli/bin/cli.js
+++ b/packages/cms-cli/bin/cli.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+const yargs = require('yargs');
+const updateNotifier = require('update-notifier');
+
+const { logger } = require('@hubspot/cms-lib/logger');
+const { logErrorInstance } = require('@hubspot/cms-lib/errorHandlers');
+
+const { setLogLevel, getCommandName } = require('../lib/commonOpts');
+const { trackHelpUsage } = require('../lib/usageTracking');
+const pkg = require('../package.json');
+
+const removeCommand = require('../commands/remove');
+
+const SCRIPT_NAME = 'banjo';
+const notifier = updateNotifier({ pkg });
+
+notifier.notify({
+  shouldNotifyInNpmScript: true,
+});
+
+const argv = yargs
+  .scriptName(SCRIPT_NAME)
+  .usage('Tools for working with the HubSpot CMS')
+  .middleware([setLogLevel])
+  .exitProcess(false)
+  .fail((msg, err /*, _yargs*/) => {
+    if (msg) logger.error(msg);
+    if (err) logErrorInstance(err);
+  })
+  .command(removeCommand)
+  .help()
+  .demandCommand(
+    1,
+    `Please specifiy a command or run \`${SCRIPT_NAME} --help\` for a list of available commands`
+  )
+  .recommendCommands()
+  .strict().argv;
+
+if (argv.help) {
+  trackHelpUsage(getCommandName(argv));
+}

--- a/packages/cms-cli/commands/remove.js
+++ b/packages/cms-cli/commands/remove.js
@@ -26,11 +26,44 @@ const {
 } = require('../lib/usageTracking');
 
 const COMMAND_NAME = 'remove';
+const DESCRIPTION = 'Delete a file or folder from HubSpot';
+
+async function action(args, options) {
+  setLogLevel(options);
+  logDebugInfo(options);
+  const { config: configPath } = options;
+  loadConfig(configPath);
+  checkAndWarnGitInclusion();
+
+  if (!(validateConfig() && (await validatePortal(options)))) {
+    process.exit(1);
+  }
+
+  const portalId = getPortalId(options);
+
+  trackCommandUsage(COMMAND_NAME, {}, portalId);
+
+  const { hsPath } = args;
+
+  try {
+    await deleteFile(portalId, hsPath);
+    logger.log(`Deleted "${hsPath}" from portal ${portalId}`);
+  } catch (error) {
+    logger.error(`Deleting "${hsPath}" from portal ${portalId} failed`);
+    logApiErrorInstance(
+      error,
+      new ApiErrorContext({
+        portalId,
+        request: hsPath,
+      })
+    );
+  }
+}
 
 function configureRemoveCommand(program) {
   program
     .version(version)
-    .description('Delete a file or folder from HubSpot')
+    .description(DESCRIPTION)
     .arguments('<path>')
     .action(async (hsPath, command = {}) => {
       setLogLevel(command);
@@ -42,24 +75,7 @@ function configureRemoveCommand(program) {
       if (!(validateConfig() && (await validatePortal(command)))) {
         process.exit(1);
       }
-
-      const portalId = getPortalId(command);
-
-      trackCommandUsage(COMMAND_NAME, {}, portalId);
-
-      try {
-        await deleteFile(portalId, hsPath);
-        logger.log(`Deleted "${hsPath}" from portal ${portalId}`);
-      } catch (error) {
-        logger.error(`Deleting "${hsPath}" from portal ${portalId} failed`);
-        logApiErrorInstance(
-          error,
-          new ApiErrorContext({
-            portalId,
-            request: hsPath,
-          })
-        );
-      }
+      await action({ hsPath }, command);
     });
 
   addConfigOptions(program);
@@ -67,7 +83,22 @@ function configureRemoveCommand(program) {
   addLoggerOptions(program);
   addHelpUsageTracking(program, COMMAND_NAME);
 }
+exports.command = `${COMMAND_NAME} <path>`;
 
-module.exports = {
-  configureRemoveCommand,
+exports.describe = DESCRIPTION;
+
+exports.builder = yargs => {
+  addConfigOptions(yargs, true);
+  addPortalOptions(yargs, true);
+  yargs.positional('path', {
+    describe: 'Remote hubspot path',
+    type: 'string',
+  });
+  return yargs;
 };
+
+exports.handler = async function(argv) {
+  await action({ hsPath: argv.path }, argv);
+};
+
+exports.configureRemoveCommand = configureRemoveCommand;

--- a/packages/cms-cli/lib/commonOpts.js
+++ b/packages/cms-cli/lib/commonOpts.js
@@ -8,15 +8,36 @@ const {
 } = require('@hubspot/cms-lib');
 const { LOG_LEVEL } = Logger;
 
-const addPortalOptions = program => {
+const addPortalOptions = (program, useYargs = false) => {
+  if (useYargs) {
+    return program.option('portal', {
+      alias: 'p',
+      describe: 'HubSpot portal id or name from config',
+    });
+  }
   program.option('--portal <portal>', 'HubSpot portal id or name from config');
 };
 
-const addLoggerOptions = program => {
+const addLoggerOptions = (program, useYargs = false) => {
+  if (useYargs) {
+    return program.option('debug', {
+      alias: 'd',
+      default: false,
+      describe: 'set log level to debug',
+      type: 'boolean',
+    });
+  }
   program.option('--debug', 'set log level to debug', () => true, false);
 };
 
-const addConfigOptions = program => {
+const addConfigOptions = (program, useYargs = false) => {
+  if (useYargs) {
+    return program.option('config', {
+      alias: 'c',
+      describe: 'path to a config file',
+      type: 'string',
+    });
+  }
   program.option('--config <config>', 'path to a config file');
 };
 
@@ -46,6 +67,12 @@ const setLogLevel = (options = {}) => {
     Logger.setLogLevel(LOG_LEVEL.LOG);
   }
 };
+
+/**
+ * Get command name from Yargs `argv`
+ * @param {object} argv
+ */
+const getCommandName = argv => (argv && argv._ && argv._[0]) || '';
 
 /**
  * Obtains portalId using supplied --portal flag or from environment variables
@@ -87,7 +114,8 @@ module.exports = {
   addOverwriteOptions,
   addModeOptions,
   addTestingOptions,
-  setLogLevel,
-  getPortalId,
+  getCommandName,
   getMode,
+  getPortalId,
+  setLogLevel,
 };

--- a/packages/cms-cli/package.json
+++ b/packages/cms-cli/package.json
@@ -16,12 +16,14 @@
     "ora": "^4.0.3",
     "readline": "^1.3.0",
     "shelljs": "0.8.3",
-    "update-notifier": "3.0.1"
+    "update-notifier": "3.0.1",
+    "yargs": "15.4.1"
   },
   "engines": {
     "node": ">=8.9.1"
   },
   "bin": {
+    "banjo": "./bin/cli.js",
     "hs": "./bin/hs.js",
     "hscms": "./bin/hscms.js"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1512,7 +1512,7 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.1.0:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
   integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
@@ -2143,6 +2143,15 @@ cliui@^5.0.0:
     string-width "^3.1.0"
     strip-ansi "^5.2.0"
     wrap-ansi "^5.1.0"
+
+cliui@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
+  integrity sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^6.2.0"
 
 clone-deep@^4.0.1:
   version "4.0.1"
@@ -3448,6 +3457,14 @@ find-up@^3.0.0:
   integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
   dependencies:
     locate-path "^3.0.0"
+
+find-up@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
+  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
+  dependencies:
+    locate-path "^5.0.0"
+    path-exists "^4.0.0"
 
 find@^0.3.0:
   version "0.3.0"
@@ -5344,6 +5361,13 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
+locate-path@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
+  integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
+  dependencies:
+    p-locate "^4.1.0"
+
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -6307,6 +6331,13 @@ p-limit@^2.0.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
+  integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -6320,6 +6351,13 @@ p-locate@^3.0.0:
   integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
   dependencies:
     p-limit "^2.0.0"
+
+p-locate@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
+  integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
+  dependencies:
+    p-limit "^2.2.0"
 
 p-map-series@^1.0.0:
   version "1.0.0"
@@ -6492,6 +6530,11 @@ path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
   integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
+
+path-exists@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
+  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -7713,7 +7756,7 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string-width@^4.1.0:
+string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
   integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
@@ -8510,6 +8553,15 @@ wrap-ansi@^5.1.0:
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
 
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -8631,6 +8683,31 @@ yargs-parser@^15.0.1:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
+
+yargs-parser@^18.1.2:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs@15.4.1:
+  version "15.4.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
+  integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^18.1.2"
 
 yargs@^13.3.0:
   version "13.3.2"


### PR DESCRIPTION
Let's kickstart the process to make the shift to [yargs](https://github.com/yargs/yargs) again. This PR proposes a migration strategy where we refactor [commands](https://github.com/HubSpot/hubspot-cms-tools/tree/master/packages/cms-cli/commands) to support both `Commander.js` and `yargs` through sharing the core action logic for each command between the two. It borrows from #47 with a few adjustments.

This will allow us to make the process gradually and not block any enhancements or bug fixes that we want to get out before we're ready to switch entirely over to `yargs`.

@miketalley @anthmatic 