### PR TITLE
Added hs create vue-app command

### DIFF
--- a/packages/cms-cli/commands/create.js
+++ b/packages/cms-cli/commands/create.js
@@ -30,6 +30,7 @@ const TYPES = {
   template: 'template',
   'website-theme': 'website-theme',
   'react-app': 'react-app',
+  'vue-app': 'vue-app',
   'webpack-serverless': 'webpack-serverless',
 };
 
@@ -44,6 +45,7 @@ const ASSET_PATHS = {
 
 const PROJECT_REPOSITORIES = {
   [TYPES['react-app']]: 'cms-react-boilerplate',
+  [TYPES['vue-app']]: 'cms-vue-boilerplate',
   [TYPES['website-theme']]: 'cms-theme-boilerplate',
   [TYPES['webpack-serverless']]: 'cms-webpack-serverless-boilerplate',
 };
@@ -155,6 +157,7 @@ function configureCreateCommand(program) {
           break;
         case TYPES['website-theme']:
         case TYPES['react-app']:
+        case TYPES['vue-app']:
         case TYPES['webpack-serverless']:
           dest = name || type;
           break;
@@ -191,6 +194,7 @@ function configureCreateCommand(program) {
           createProject(dest, type, PROJECT_REPOSITORIES[type], 'src', program);
           break;
         case TYPES['react-app']:
+        case TYPES['vue-app']:
         case TYPES['webpack-serverless']: {
           createProject(dest, type, PROJECT_REPOSITORIES[type], '', program);
           break;


### PR DESCRIPTION
Using the functionality for `hs create react-app` we now have `hs create vue-app` which generates a boilerplate [Vue](https://vuejs.org/) module app using [cms-vue-boilerplate](https://github.com/HubSpot/cms-vue-boilerplate).

Fixes #217 