### PR TITLE
Added hs create vue-app that utilizes vue-cli init command

### DIFF
--- a/packages/cms-cli/commands/create.js
+++ b/packages/cms-cli/commands/create.js
@@ -7,7 +7,10 @@ const {
 } = require('@hubspot/cms-lib/errorHandlers');
 const { getPortalId } = require('@hubspot/cms-lib');
 const { logger } = require('@hubspot/cms-lib/logger');
-const { createProject } = require('@hubspot/cms-lib/projects');
+const {
+  createProject,
+  createVueProject,
+} = require('@hubspot/cms-lib/projects');
 const { createFunction } = require('@hubspot/cms-lib/functions');
 
 const { addLoggerOptions, setLogLevel } = require('../lib/commonOpts');
@@ -30,6 +33,7 @@ const TYPES = {
   template: 'template',
   'website-theme': 'website-theme',
   'react-app': 'react-app',
+  'vue-app': 'vue-app',
   'webpack-serverless': 'webpack-serverless',
 };
 
@@ -56,6 +60,7 @@ const ASSET_PATHS = {
 
 const PROJECT_REPOSITORIES = {
   [TYPES['react-app']]: 'cms-react-boilerplate',
+  [TYPES['vue-app']]: 'cms-vue-module-template',
   [TYPES['website-theme']]: 'cms-theme-boilerplate',
   [TYPES['webpack-serverless']]: 'cms-webpack-serverless-boilerplate',
 };
@@ -171,6 +176,7 @@ function configureCreateCommand(program) {
           break;
         case TYPES['website-theme']:
         case TYPES['react-app']:
+        case TYPES['vue-app']:
         case TYPES['webpack-serverless']:
           dest = name || type;
           break;
@@ -217,6 +223,10 @@ function configureCreateCommand(program) {
         case TYPES['react-app']:
         case TYPES['webpack-serverless']: {
           createProject(dest, type, PROJECT_REPOSITORIES[type], '', program);
+          break;
+        }
+        case TYPES['vue-app']: {
+          await createVueProject(dest, type, PROJECT_REPOSITORIES[type]);
           break;
         }
         case TYPES.function: {

--- a/packages/cms-cli/commands/create.js
+++ b/packages/cms-cli/commands/create.js
@@ -187,7 +187,7 @@ function configureCreateCommand(program) {
       dest = resolveLocalPath(dest);
 
       try {
-        await fs.ensureDir(dest);
+        await fs.exists(dest);
       } catch (e) {
         logger.error(`The "${dest}" is not a usable path to a directory`);
         logFileSystemErrorInstance(e, {

--- a/packages/cms-lib/functions.js
+++ b/packages/cms-lib/functions.js
@@ -131,6 +131,8 @@ function createFunction(
   if (fs.existsSync(functionFilePath)) {
     logger.error(`The JavaScript file at "${functionFilePath}" already exists`);
     return;
+  } else {
+    fs.ensureFileSync(functionFilePath);
   }
 
   try {

--- a/packages/cms-lib/projects.js
+++ b/packages/cms-lib/projects.js
@@ -186,12 +186,12 @@ async function createProject(dest, type, repoName, sourceDir, options = {}) {
  * @returns {Boolean} `true` if successful, `false` otherwise.
  */
 async function createVueProject(dest, type, repoName) {
-  const projectDestinationFolder = dest.match(/([^/]*)\/*$/)[1];
+  const relativePath = path.relative(process.cwd(), dest);
 
   return new Promise(resolve => {
     const vueInit = spawn(
       'vue',
-      ['init', `HubSpot/${repoName}`, projectDestinationFolder],
+      ['init', `HubSpot/${repoName}`, relativePath],
       {
         stdio: 'inherit',
         shell: false,

--- a/packages/cms-lib/projects.js
+++ b/packages/cms-lib/projects.js
@@ -189,7 +189,7 @@ async function createVueProject(dest, type, repoName) {
   const projectDestinationFolder = dest.match(/([^/]*)\/*$/)[1];
 
   return new Promise(resolve => {
-    const spwan = spawn(
+    const vueInit = spawn(
       'vue',
       ['init', `HubSpot/${repoName}`, projectDestinationFolder],
       {
@@ -198,7 +198,7 @@ async function createVueProject(dest, type, repoName) {
       }
     );
 
-    spwan.on('exit', () => {
+    vueInit.on('exit', () => {
       resolve();
     });
   });

--- a/packages/cms-lib/projects.js
+++ b/packages/cms-lib/projects.js
@@ -1,6 +1,7 @@
 const fs = require('fs-extra');
 const path = require('path');
 const os = require('os');
+const { spawn } = require('child_process');
 const { promisify } = require('util');
 
 const request = require('request-promise-native');
@@ -175,8 +176,37 @@ async function createProject(dest, type, repoName, sourceDir, options = {}) {
   return success;
 }
 
+/**
+ * Writes a copy of the boilerplate project to dest.
+ * @param {String} dest - Dir to write project src to.
+ * @param {String} type - Type of project to create.
+ * @param {String} repoName - Name of GitHub repository to clone.
+ * @param {String} sourceDir - Directory in project that should get copied.
+ * @param {Object} options
+ * @returns {Boolean} `true` if successful, `false` otherwise.
+ */
+async function createVueProject(dest, type, repoName) {
+  const projectDestinationFolder = dest.match(/([^/]*)\/*$/)[1];
+
+  return new Promise(resolve => {
+    const spwan = spawn(
+      'vue',
+      ['init', `HubSpot/${repoName}`, projectDestinationFolder],
+      {
+        stdio: 'inherit',
+        shell: false,
+      }
+    );
+
+    spwan.on('exit', () => {
+      resolve();
+    });
+  });
+}
+
 module.exports = {
   createProject,
+  createVueProject,
   downloadProject,
   extractProjectZip,
   fetchReleaseData,


### PR DESCRIPTION
This adds the `hs create vue-app <destinationFolder>` command which generates a boilerplate Vue module app using the [vue-cli](https://cli.vuejs.org/) and the [cms-vue-module-template repo](https://github.com/HubSpot/cms-vue-module-template). It is the equivalent of running `vue init HubSpot/cms-vue-module-template <destinationFolder>`.

![image](https://user-images.githubusercontent.com/6472448/90048538-a851cd00-dca1-11ea-95d5-be98f0e29b8f.png)

![image](https://user-images.githubusercontent.com/6472448/90048704-ddf6b600-dca1-11ea-8a04-22832f289a51.png)


Fixes #217