### PR TITLE
Added hs create vue-app command(back again)

### DIFF
--- a/packages/cms-cli/commands/create.js
+++ b/packages/cms-cli/commands/create.js
@@ -30,6 +30,7 @@ const TYPES = {
   template: 'template',
   'website-theme': 'website-theme',
   'react-app': 'react-app',
+  'vue-app': 'vue-app',
   'webpack-serverless': 'webpack-serverless',
 };
 
@@ -56,6 +57,7 @@ const ASSET_PATHS = {
 
 const PROJECT_REPOSITORIES = {
   [TYPES['react-app']]: 'cms-react-boilerplate',
+  [TYPES['vue-app']]: 'cms-vue-boilerplate',
   [TYPES['website-theme']]: 'cms-theme-boilerplate',
   [TYPES['webpack-serverless']]: 'cms-webpack-serverless-boilerplate',
 };
@@ -171,6 +173,7 @@ function configureCreateCommand(program) {
           break;
         case TYPES['website-theme']:
         case TYPES['react-app']:
+        case TYPES['vue-app']:
         case TYPES['webpack-serverless']:
           dest = name || type;
           break;
@@ -215,6 +218,7 @@ function configureCreateCommand(program) {
           createProject(dest, type, PROJECT_REPOSITORIES[type], 'src', program);
           break;
         case TYPES['react-app']:
+        case TYPES['vue-app']:
         case TYPES['webpack-serverless']: {
           createProject(dest, type, PROJECT_REPOSITORIES[type], '', program);
           break;


### PR DESCRIPTION
Using the functionality for `hs create react-app` we now have `hs create vue-app` which generates a boilerplate Vue module app using the [cms-vue-boilerplate](https://github.com/HubSpot/cms-vue-boilerplate).

This was originally added in https://github.com/HubSpot/hubspot-cms-tools/pull/266 and then reverted in https://github.com/HubSpot/hubspot-cms-tools/pull/278 so we could get a release out while doing research on `vue init` command to generate a module using [a vue module template](https://github.com/HubSpot/cms-vue-module-template).

Fixes #217