### PR TITLE
Bail on yargs errors

### DIFF
--- a/packages/cms-cli/bin/cli.js
+++ b/packages/cms-cli/bin/cli.js
@@ -5,7 +5,6 @@ const updateNotifier = require('update-notifier');
 
 const { logger } = require('@hubspot/cms-lib/logger');
 const { logErrorInstance } = require('@hubspot/cms-lib/errorHandlers');
-
 const { setLogLevel, getCommandName } = require('../lib/commonOpts');
 const { trackHelpUsage } = require('../lib/usageTracking');
 const pkg = require('../package.json');
@@ -35,9 +34,16 @@ const argv = yargs
   .usage('Tools for working with the HubSpot CMS')
   .middleware([setLogLevel])
   .exitProcess(false)
-  .fail((msg, err /*, _yargs*/) => {
+  .fail((msg, err, _yargs) => {
+    // Preserve stack trace.
+    if (err) throw err;
+
     if (msg) logger.error(msg);
     if (err) logErrorInstance(err);
+
+    // Give command-specifc help
+    console.log(_yargs.help());
+    process.exit(0);
   })
   .option('debug', {
     alias: 'd',


### PR DESCRIPTION
Yargs would continue to try to run the command even if required arguments were not present.  Now we bail and give the user information on why the command failed