### PR TITLE
Only write files on successful fetch

### DIFF
--- a/packages/cms-lib/__mocks__/fs-extra.js
+++ b/packages/cms-lib/__mocks__/fs-extra.js
@@ -30,6 +30,13 @@ fs.readFileSync = () => mockedReadFile;
 fs.existsSync = () => mockedExistsValue;
 fs.writeFileSync = () => true;
 fs.unlinkSync = () => true;
+fs.createWriteStream = jest.fn().mockReturnValue({
+  on: jest.fn((val, cb) => {
+    if (val === 'close') {
+      cb();
+    }
+  }),
+});
 fs.outputFile = jest.fn((dest, data) => {
   return data;
 });

--- a/packages/cms-lib/__mocks__/fs-extra.js
+++ b/packages/cms-lib/__mocks__/fs-extra.js
@@ -31,9 +31,9 @@ fs.existsSync = () => mockedExistsValue;
 fs.writeFileSync = () => true;
 fs.unlinkSync = () => true;
 fs.createWriteStream = jest.fn().mockReturnValue({
-  on: jest.fn((val, cb) => {
-    if (val === 'close') {
-      cb();
+  on: jest.fn((event, callback) => {
+    if (event === 'close') {
+      callback();
     }
   }),
 });

--- a/packages/cms-lib/__tests__/http.js
+++ b/packages/cms-lib/__tests__/http.js
@@ -119,7 +119,7 @@ describe('http', () => {
           'path/to/local/file'
         );
       } catch (e) {
-        expect(e).rejects;
+        expect(e.statusCode).toBe(404);
       }
     });
   });

--- a/packages/cms-lib/__tests__/http.js
+++ b/packages/cms-lib/__tests__/http.js
@@ -22,9 +22,9 @@ jest.mock('request', () => ({
       }
     };
     return {
-      on: jest.fn((val, cb) => {
-        if (val === 'response') {
-          cb({ statusCode: isValidPath(uri) ? 200 : 404 });
+      on: jest.fn((event, callback) => {
+        if (event === 'response') {
+          callback({ statusCode: isValidPath(uri) ? 200 : 404 });
         }
       }),
       pipe: jest.fn(),

--- a/packages/cms-lib/__tests__/http.js
+++ b/packages/cms-lib/__tests__/http.js
@@ -41,7 +41,7 @@ describe('http', () => {
     getPortalConfig.mockReset();
   });
   describe('getOctetStream()', () => {
-    it('makes a get request', async () => {
+    beforeEach(() => {
       getAndLoadConfigIfNeeded.mockReturnValue({
         httpTimeout: 1000,
         portals: [
@@ -55,7 +55,8 @@ describe('http', () => {
         id: 123,
         apiKey: 'abc',
       });
-
+    });
+    it('makes a get request', async () => {
       await http.getOctetStream(
         123,
         {
@@ -69,20 +70,6 @@ describe('http', () => {
       );
     });
     it('fetches a file and attempts to write it', async () => {
-      getAndLoadConfigIfNeeded.mockReturnValue({
-        httpTimeout: 1000,
-        portals: [
-          {
-            id: 123,
-            apiKey: 'abc',
-          },
-        ],
-      });
-      getPortalConfig.mockReturnValue({
-        id: 123,
-        apiKey: 'abc',
-      });
-
       await http.getOctetStream(
         123,
         {
@@ -96,20 +83,6 @@ describe('http', () => {
       });
     });
     it('fails to fetch a file and throws', async () => {
-      getAndLoadConfigIfNeeded.mockReturnValue({
-        httpTimeout: 1000,
-        portals: [
-          {
-            id: 123,
-            apiKey: 'abc',
-          },
-        ],
-      });
-      getPortalConfig.mockReturnValue({
-        id: 123,
-        apiKey: 'abc',
-      });
-
       try {
         await http.getOctetStream(
           123,

--- a/packages/cms-lib/__tests__/http.js
+++ b/packages/cms-lib/__tests__/http.js
@@ -12,25 +12,7 @@ jest.mock('request-promise-native', () => ({
   post: jest.fn().mockReturnValue(Promise.resolve()),
 }));
 
-jest.mock('request', () => ({
-  get: jest.fn(({ uri }) => {
-    const isValidPath = path => {
-      if (path === 'some/endpoint/path') {
-        return true;
-      } else {
-        return false;
-      }
-    };
-    return {
-      on: jest.fn((event, callback) => {
-        if (event === 'response') {
-          callback({ statusCode: isValidPath(uri) ? 200 : 404 });
-        }
-      }),
-      pipe: jest.fn(),
-    };
-  }),
-}));
+jest.mock('request');
 jest.mock('../lib/config');
 jest.mock('../logger');
 
@@ -57,6 +39,14 @@ describe('http', () => {
       });
     });
     it('makes a get request', async () => {
+      request.get.mockReturnValue({
+        on: jest.fn((event, callback) => {
+          if (event === 'response') {
+            callback({ statusCode: 200 });
+          }
+        }),
+        pipe: jest.fn(),
+      });
       await http.getOctetStream(
         123,
         {
@@ -70,6 +60,14 @@ describe('http', () => {
       );
     });
     it('fetches a file and attempts to write it', async () => {
+      request.get.mockReturnValue({
+        on: jest.fn((event, callback) => {
+          if (event === 'response') {
+            callback({ statusCode: 200 });
+          }
+        }),
+        pipe: jest.fn(),
+      });
       await http.getOctetStream(
         123,
         {
@@ -83,6 +81,14 @@ describe('http', () => {
       });
     });
     it('fails to fetch a file and throws', async () => {
+      request.get.mockReturnValue({
+        on: jest.fn((event, callback) => {
+          if (event === 'response') {
+            callback({ statusCode: 404 });
+          }
+        }),
+        pipe: jest.fn(),
+      });
       try {
         await http.getOctetStream(
           123,

--- a/packages/cms-lib/__tests__/http.js
+++ b/packages/cms-lib/__tests__/http.js
@@ -80,7 +80,7 @@ describe('http', () => {
         encoding: 'binary',
       });
     });
-    it('fails to fetch a file and throws', async () => {
+    it('fails to fetch a file and does not attempt to write to disk', async () => {
       request.get.mockReturnValue({
         on: jest.fn((event, callback) => {
           if (event === 'response') {
@@ -99,6 +99,7 @@ describe('http', () => {
         );
       } catch (e) {
         expect(e.statusCode).toBe(404);
+        expect(fs.createWriteStream).not.toBeCalled();
       }
     });
   });

--- a/packages/cms-lib/fileMapper.js
+++ b/packages/cms-lib/fileMapper.js
@@ -289,6 +289,7 @@ async function fetchAndWriteFileStream(input, srcPath, filepath) {
       qs: getFileMapperApiQueryFromMode(input.mode),
     });
   } catch (err) {
+    await fs.unlink(filepath);
     logApiErrorInstance(
       err,
       new ApiErrorContext({

--- a/packages/cms-lib/fileMapper.js
+++ b/packages/cms-lib/fileMapper.js
@@ -285,7 +285,7 @@ async function fetchAndWriteFileStream(input, srcPath, filepath) {
   }
   let node;
   try {
-    node = await fetchFileStream(portalId, srcPath, writeStream, {
+    node = await fetchFileStream(portalId, srcPath, filepath, {
       qs: getFileMapperApiQueryFromMode(input.mode),
     });
   } catch (err) {

--- a/packages/cms-lib/fileMapper.js
+++ b/packages/cms-lib/fileMapper.js
@@ -265,31 +265,13 @@ async function fetchAndWriteFileStream(input, srcPath, filepath) {
     throw new Error(message);
   }
   const { portalId } = input;
-  const logFsError = err => {
-    logFileSystemErrorInstance(
-      err,
-      new FileSystemErrorContext({
-        filepath,
-        portalId,
-        write: true,
-      })
-    );
-  };
-  let writeStream;
+
   try {
-    await fs.ensureFile(filepath);
-    writeStream = fs.createWriteStream(filepath, { encoding: 'binary' });
-  } catch (err) {
-    logFsError(err);
-    throw err;
-  }
-  let node;
-  try {
-    node = await fetchFileStream(portalId, srcPath, filepath, {
+    const node = await fetchFileStream(portalId, srcPath, filepath, {
       qs: getFileMapperApiQueryFromMode(input.mode),
     });
+    await writeUtimes(input, filepath, node);
   } catch (err) {
-    await fs.unlink(filepath);
     logApiErrorInstance(
       err,
       new ApiErrorContext({
@@ -299,17 +281,6 @@ async function fetchAndWriteFileStream(input, srcPath, filepath) {
     );
     throw err;
   }
-  return new Promise((resolve, reject) => {
-    writeStream.on('error', err => {
-      logFsError(err);
-      reject(err);
-    });
-    writeStream.on('close', async () => {
-      await writeUtimes(input, filepath, node);
-      logger.log('Wrote file "%s"', filepath);
-      resolve(node);
-    });
-  });
 }
 
 /**

--- a/packages/cms-lib/http.js
+++ b/packages/cms-lib/http.js
@@ -1,5 +1,6 @@
 const request = require('request');
 const requestPN = require('request-promise-native');
+const fs = require('fs-extra');
 const { getPortalConfig } = require('./lib/config');
 const { getRequestOptions } = require('./http/requestOptions');
 const { accessTokenForPersonalAccessKey } = require('./personalAccessKey');
@@ -135,7 +136,10 @@ const createGetRequestStream = ({ contentType }) => async (
         .on('response', r => {
           if (r.statusCode >= 200 && r.statusCode < 300) {
             response = r;
-            req.pipe(destination);
+            let stream = fs.createWriteStream(destination, {
+              encoding: 'binary',
+            });
+            req.pipe(stream);
           } else {
             reject(r);
           }

--- a/packages/cms-lib/http.js
+++ b/packages/cms-lib/http.js
@@ -135,12 +135,12 @@ const createGetRequestStream = ({ contentType }) => async (
         .on('response', r => {
           if (r.statusCode >= 200 && r.statusCode < 300) {
             response = r;
+            req.pipe(destination);
           } else {
             reject(r);
           }
         })
-        .on('end', () => resolve(response))
-        .pipe(destination);
+        .on('end', () => resolve(response));
     } catch (err) {
       reject(err);
     }

--- a/packages/cms-lib/http.js
+++ b/packages/cms-lib/http.js
@@ -147,7 +147,8 @@ const createGetRequestStream = ({ contentType }) => async (
         },
         json: false,
       });
-      req.on('error', reject).on('response', res => {
+      req.on('error', reject);
+      req.on('response', res => {
         if (res.statusCode >= 200 && res.statusCode < 300) {
           const writeStream = fs.createWriteStream(filepath, {
             encoding: 'binary',


### PR DESCRIPTION
Previously, on fetch, files were getting written even when a bad request came through. Sometimes this would result in a file with the wrong content (like an HTML response body).

This moves the logic for writing files up a level and only creates a writeStream when a successful fetch has occurred.

Resolves #265 