### PR TITLE
Add autocompletion script

### DIFF
--- a/packages/cms-cli/README.md
+++ b/packages/cms-cli/README.md
@@ -29,6 +29,15 @@ cd ~
 hs init
 ```
 
+#### Auto Completion
+You can set up command autocompletion by running
+
+```bash
+hs completion
+```
+
+and copying the output to either your `.bashrc` or `.zshrc`, and then sourcing that file `source ~/.bashrc` `source ~/.zshrc` or restarting your terminal.
+
 ## Commands
 A full breakdown of the commands can be found on the [local development tools reference page](https://designers.hubspot.com/docs/developer-reference/local-development-cms-cli).
 

--- a/packages/cms-cli/bin/cli.js
+++ b/packages/cms-cli/bin/cli.js
@@ -66,6 +66,7 @@ const argv = yargs
   .help()
   .recommendCommands()
   .demandCommand(1, '')
+  .completion()
   .strict().argv;
 
 if (argv.help) {


### PR DESCRIPTION
Take advantage of yargs autcompletion script. I was looking to see if there was a way to modify the output so we could add a bit more detail about the installation instructions but I couldn't find anything in the docs about it.  

![2020-10-05 12 55 55](https://user-images.githubusercontent.com/5521743/95109927-434bae00-070b-11eb-855f-e2c5db60a8f0.gif)
