### PR TITLE
Prompt for secret values

### DIFF
--- a/packages/cms-cli/commands/secrets/addSecret.js
+++ b/packages/cms-cli/commands/secrets/addSecret.js
@@ -21,12 +21,13 @@ const {
   getPortalId,
 } = require('../../lib/commonOpts');
 const { logDebugInfo } = require('../../lib/debugInfo');
+const { secretValuePrompt } = require('../lib/secretPrompt');
 
 exports.command = 'add <name> <value>';
 exports.describe = 'Add a HubSpot secret';
 
 exports.handler = async options => {
-  const { config: configPath, name: secretName, value: secretValue } = options;
+  const { config: configPath, name: secretName } = options;
 
   setLogLevel(options);
   logDebugInfo(options);
@@ -40,6 +41,8 @@ exports.handler = async options => {
   trackCommandUsage('secrets-add', {}, portalId);
 
   try {
+    const secretValue = secretValuePrompt();
+
     await addSecret(portalId, secretName, secretValue);
     logger.log(
       `The secret "${secretName}" was added to the HubSpot portal: ${portalId}`

--- a/packages/cms-cli/commands/secrets/addSecret.js
+++ b/packages/cms-cli/commands/secrets/addSecret.js
@@ -21,9 +21,9 @@ const {
   getPortalId,
 } = require('../../lib/commonOpts');
 const { logDebugInfo } = require('../../lib/debugInfo');
-const { secretValuePrompt } = require('../lib/secretPrompt');
+const { secretValuePrompt } = require('../../lib/secretPrompt');
 
-exports.command = 'add <name> <value>';
+exports.command = 'add <name>';
 exports.describe = 'Add a HubSpot secret';
 
 exports.handler = async options => {

--- a/packages/cms-cli/commands/secrets/addSecret.js
+++ b/packages/cms-cli/commands/secrets/addSecret.js
@@ -41,7 +41,7 @@ exports.handler = async options => {
   trackCommandUsage('secrets-add', {}, portalId);
 
   try {
-    const secretValue = secretValuePrompt();
+    const { secretValue } = await secretValuePrompt();
 
     await addSecret(portalId, secretName, secretValue);
     logger.log(

--- a/packages/cms-cli/commands/secrets/addSecret.js
+++ b/packages/cms-cli/commands/secrets/addSecret.js
@@ -68,9 +68,5 @@ exports.builder = yargs => {
     describe: 'Name of the secret',
     type: 'string',
   });
-  yargs.positional('value', {
-    describe: 'The secret to be stored such as an API key',
-    type: 'string',
-  });
   return yargs;
 };

--- a/packages/cms-cli/commands/secrets/updateSecret.js
+++ b/packages/cms-cli/commands/secrets/updateSecret.js
@@ -21,12 +21,13 @@ const {
   getPortalId,
 } = require('../../lib/commonOpts');
 const { logDebugInfo } = require('../../lib/debugInfo');
+const { secretValuePrompt } = require('../../lib/secretPrompt');
 
-exports.command = 'update <name> <value>';
+exports.command = 'update <name>';
 exports.describe = 'Update an existing HubSpot secret';
 
 exports.handler = async options => {
-  const { name: secretName, value: secretValue, config: configPath } = options;
+  const { name: secretName, config: configPath } = options;
 
   setLogLevel(options);
   logDebugInfo(options);
@@ -40,6 +41,8 @@ exports.handler = async options => {
   trackCommandUsage('secrets-update', {}, portalId);
 
   try {
+    const { secretValue } = await secretValuePrompt();
+
     await updateSecret(portalId, secretName, secretValue);
     logger.log(
       `The secret "${secretName}" was updated in the HubSpot portal: ${portalId}`

--- a/packages/cms-cli/commands/secrets/updateSecret.js
+++ b/packages/cms-cli/commands/secrets/updateSecret.js
@@ -68,9 +68,5 @@ exports.builder = yargs => {
     describe: 'Name of the secret to be updated',
     type: 'string',
   });
-  yargs.positional('value', {
-    describe: 'The secret to be stored',
-    type: 'string',
-  });
   return yargs;
 };

--- a/packages/cms-cli/lib/secretPrompt.js
+++ b/packages/cms-cli/lib/secretPrompt.js
@@ -1,0 +1,20 @@
+const inquirer = require('inquirer');
+
+const SECRET_VALUE_PROMPT = {
+  name: 'secretValue',
+  message: 'What is the value of your secret',
+  validate(val) {
+    if (typeof val !== 'string') {
+      return 'You entered an invalid value. Please try again.';
+    }
+    return true;
+  },
+};
+
+function secretValuePrompt() {
+  const prompt = inquirer.createPromptModule();
+  return prompt([SECRET_VALUE_PROMPT]);
+}
+module.exports = {
+  secretValuePrompt,
+};

--- a/packages/cms-cli/lib/secretPrompt.js
+++ b/packages/cms-cli/lib/secretPrompt.js
@@ -3,6 +3,7 @@ const inquirer = require('inquirer');
 const SECRET_VALUE_PROMPT = {
   name: 'secretValue',
   type: 'password',
+  mask: '*',
   message: 'Enter a value for your secret',
   validate(val) {
     if (typeof val !== 'string') {

--- a/packages/cms-cli/lib/secretPrompt.js
+++ b/packages/cms-cli/lib/secretPrompt.js
@@ -2,7 +2,8 @@ const inquirer = require('inquirer');
 
 const SECRET_VALUE_PROMPT = {
   name: 'secretValue',
-  message: 'What is the value of your secret',
+  type: 'password',
+  message: 'Enter a value for your secret',
   validate(val) {
     if (typeof val !== 'string') {
       return 'You entered an invalid value. Please try again.';


### PR DESCRIPTION
Removes the `value` argument from `hs secrets add` and `hs secrets update` and replaces it with a prompt where the use can input their secret as a masked input like:
```
? Enter a value for your secret *****
```