### PR TITLE
hs functions list command

### DIFF
--- a/packages/cms-cli/bin/cli.js
+++ b/packages/cms-cli/bin/cli.js
@@ -22,6 +22,7 @@ const fetchCommand = require('../commands/fetch');
 const filemanagerCommand = require('../commands/filemanager');
 const secretsCommand = require('../commands/secrets');
 const customObjectCommand = require('../commands/customObject');
+const functionsCommand = require('../commands/functions');
 
 const notifier = updateNotifier({ pkg });
 
@@ -63,6 +64,7 @@ const argv = yargs
   .command(filemanagerCommand)
   .command(secretsCommand)
   .command(customObjectCommand)
+  .command(functionsCommand)
   .help()
   .recommendCommands()
   .demandCommand(1, '')

--- a/packages/cms-cli/commands/functions.js
+++ b/packages/cms-cli/commands/functions.js
@@ -13,7 +13,12 @@ exports.builder = yargs => {
   addConfigOptions(yargs, true);
   addPortalOptions(yargs, true);
 
-  yargs.command(list).demandCommand(1, '');
+  yargs
+    .command({
+      ...list,
+      aliases: 'ls',
+    })
+    .demandCommand(1, '');
 
   return yargs;
 };

--- a/packages/cms-cli/commands/functions.js
+++ b/packages/cms-cli/commands/functions.js
@@ -1,0 +1,19 @@
+const {
+  addConfigOptions,
+  addPortalOptions,
+  addOverwriteOptions,
+} = require('../lib/commonOpts');
+const list = require('./functions/list');
+
+exports.command = 'functions';
+exports.describe = 'Commands for working with functions';
+
+exports.builder = yargs => {
+  addOverwriteOptions(yargs, true);
+  addConfigOptions(yargs, true);
+  addPortalOptions(yargs, true);
+
+  yargs.command(list).demandCommand(1, '');
+
+  return yargs;
+};

--- a/packages/cms-cli/commands/functions/list.js
+++ b/packages/cms-cli/commands/functions/list.js
@@ -69,6 +69,7 @@ exports.builder = yargs => {
   yargs
     .options({
       compact: {
+        alias: 'c',
         describe: 'output compact data',
         type: 'boolean',
       },

--- a/packages/cms-cli/commands/functions/list.js
+++ b/packages/cms-cli/commands/functions/list.js
@@ -69,7 +69,6 @@ exports.builder = yargs => {
   yargs
     .options({
       compact: {
-        alias: 'c',
         describe: 'output compact data',
         type: 'boolean',
       },

--- a/packages/cms-cli/commands/functions/list.js
+++ b/packages/cms-cli/commands/functions/list.js
@@ -1,7 +1,7 @@
 const { getRoutes } = require('@hubspot/cms-lib/api/function');
 const { logger } = require('@hubspot/cms-lib/logger');
 const {
-  logServerlessFunctionApiErrorInstance,
+  logApiErrorInstance,
   ApiErrorContext,
 } = require('@hubspot/cms-lib/errorHandlers');
 const { outputFunctions } = require('@hubspot/cms-lib/lib/functions');
@@ -48,15 +48,9 @@ exports.handler = async options => {
   logger.debug('Getting currently deployed functions');
 
   const routesResp = await getRoutes(portalId).catch(async e => {
-    await logServerlessFunctionApiErrorInstance(
-      portalId,
-      e,
-      new ApiErrorContext({ portalId })
-    );
+    await logApiErrorInstance(portalId, e, new ApiErrorContext({ portalId }));
     process.exit();
   });
-
-  logger.debug(`Retrieving logs for functionId: ${routesResp.id}`);
 
   return outputFunctions(routesResp, options);
 };

--- a/packages/cms-cli/commands/functions/list.js
+++ b/packages/cms-cli/commands/functions/list.js
@@ -1,0 +1,81 @@
+const { getRoutes } = require('@hubspot/cms-lib/api/function');
+const { logger } = require('@hubspot/cms-lib/logger');
+const {
+  logServerlessFunctionApiErrorInstance,
+  ApiErrorContext,
+} = require('@hubspot/cms-lib/errorHandlers');
+const { outputFunctions } = require('@hubspot/cms-lib/lib/functions');
+const {
+  loadConfig,
+  validateConfig,
+  checkAndWarnGitInclusion,
+} = require('@hubspot/cms-lib');
+
+const {
+  addConfigOptions,
+  addPortalOptions,
+  addUseEnvironmentOptions,
+  getPortalId,
+  setLogLevel,
+} = require('../../lib/commonOpts');
+const { trackCommandUsage } = require('../../lib/usageTracking');
+const { logDebugInfo } = require('../../lib/debugInfo');
+const { validatePortal } = require('../../lib/validation');
+
+const loadAndValidateOptions = async options => {
+  setLogLevel(options);
+  logDebugInfo(options);
+  const { config: configPath } = options;
+  loadConfig(configPath, options);
+  checkAndWarnGitInclusion();
+
+  if (!(validateConfig() && (await validatePortal(options)))) {
+    process.exit(1);
+  }
+};
+
+exports.command = 'list';
+exports.describe = 'List currently deployed functions';
+
+exports.handler = async options => {
+  loadAndValidateOptions(options);
+
+  const { json, compact } = options;
+  const portalId = getPortalId(options);
+
+  trackCommandUsage('functions-list', { json, compact }, portalId);
+
+  logger.debug('Getting currently deployed functions');
+
+  const routesResp = await getRoutes(portalId).catch(async e => {
+    await logServerlessFunctionApiErrorInstance(
+      portalId,
+      e,
+      new ApiErrorContext({ portalId })
+    );
+    process.exit();
+  });
+
+  logger.debug(`Retrieving logs for functionId: ${routesResp.id}`);
+
+  return outputFunctions(routesResp, options);
+};
+
+exports.builder = yargs => {
+  addConfigOptions(yargs, true);
+  addPortalOptions(yargs, true);
+  addUseEnvironmentOptions(yargs, true);
+
+  yargs
+    .options({
+      compact: {
+        describe: 'output compact data',
+        type: 'boolean',
+      },
+      json: {
+        describe: 'output raw json data',
+        type: 'boolean',
+      },
+    })
+    .conflicts('compact', 'json');
+};

--- a/packages/cms-lib/api/function.js
+++ b/packages/cms-lib/api/function.js
@@ -1,13 +1,20 @@
 const http = require('../http');
 
-const FUNCTION_API_PATH = 'cms/v3/functions/function';
+const FUNCTION_API_PATH = 'cms/v3/functions';
 
 async function getFunctionByPath(portalId, functionPath) {
   return http.get(portalId, {
-    uri: `${FUNCTION_API_PATH}/by-path/${functionPath}`,
+    uri: `${FUNCTION_API_PATH}/function/by-path/${functionPath}`,
+  });
+}
+
+async function getRoutes(portalId) {
+  return http.get(portalId, {
+    uri: `${FUNCTION_API_PATH}/routes`,
   });
 }
 
 module.exports = {
   getFunctionByPath,
+  getRoutes,
 };

--- a/packages/cms-lib/lib/functions.js
+++ b/packages/cms-lib/lib/functions.js
@@ -4,19 +4,18 @@ const util = require('util');
 const { logger } = require('../logger');
 
 const formatCompactOutput = func => {
-  return `${func.method}\t/${func.route} (https://mtalley-101867970.hs-sitesqa.com/_hcms/api/${func.route})`;
+  return `${func.method}\t/${func.route}`;
 };
 
 const formatFullOutput = func => {
-  return `/${
-    func.route
-  }\nURL: https://mtalley-101867970.hs-sitesqa.com/_hcms/api/${
-    func.route
-  }\nMethod: ${func.method}\nSecrets: ${util.inspect(func.secretNames, {
-    colors: true,
-    compact: true,
-    depth: 'Infinity',
-  })}\nCreated: ${func.created} (${moment(func.created).format()})\nUpdated: ${
+  return `/${func.route}\nMethod: ${func.method}\nSecrets: ${util.inspect(
+    func.secretNames,
+    {
+      colors: true,
+      compact: true,
+      depth: 'Infinity',
+    }
+  )}\nCreated: ${func.created} (${moment(func.created).format()})\nUpdated: ${
     func.updated
   } (${moment(func.updated).format()})\n`;
 };

--- a/packages/cms-lib/lib/functions.js
+++ b/packages/cms-lib/lib/functions.js
@@ -1,0 +1,103 @@
+// const util = require('util');
+// const moment = require('moment');
+// const chalk = require('chalk');
+const {
+  logger,
+  // Styles
+} = require('../logger');
+
+// const SEPARATOR = ' - ';
+// const LOG_STATUS_COLORS = {
+//   SUCCESS: Styles.success,
+//   UNHANDLED_ERROR: Styles.error,
+//   HANDLED_ERROR: Styles.error,
+// };
+
+// const formatError = log => {
+//   return `/n${log.error.type}: ${log.error.message}\n${formatStackTrace(
+//     log
+//   )}\n`;
+// };
+
+// const logHandler = {
+//   UNHANDLED_ERROR: (log, { compact }) => {
+//     return `${formatLogHeader(log)}${compact ? '' : formatError(log)}`;
+//   },
+//   HANDLED_ERROR: (log, { compact }) => {
+//     return `${formatLogHeader(log)}${compact ? '' : formatError(log)}`;
+//   },
+//   SUCCESS: (log, { compact }) => {
+//     return `${formatLogHeader(log)}${compact ? '' : formatLogPayloadData(log)}`;
+//   },
+// };
+
+// const formatLogPayloadData = log => {
+//   return `\n${formatPayload(log)}\n${formatLog(log)}`;
+// };
+
+// const formatLogHeader = log => {
+//   const color = LOG_STATUS_COLORS[log.status];
+
+//   return `${formatTimestamp(log)}${SEPARATOR}${color(
+//     log.status
+//   )}${SEPARATOR}${formatExecutionTime(log)}`;
+// };
+
+// const formatLog = log => {
+//   return `${log.log}`;
+// };
+
+// const formatStackTrace = log => {
+//   const stackTrace = (log.error.stackTrace && log.error.stackTrace[0]) || [];
+//   return stackTrace
+//     .map(trace => {
+//       return `  at ${trace}\n`;
+//     })
+//     .join('');
+// };
+
+// const formatTimestamp = log => {
+//   return `${chalk.whiteBright(moment(log.createdAt).toISOString())}`;
+// };
+
+// const formatPayload = log => {
+//   return util.inspect(log.payload, {
+//     colors: true,
+//     compact: true,
+//     depth: 'Infinity',
+//   });
+// };
+
+// const formatExecutionTime = log => {
+//   return `${chalk.whiteBright('Execution Time:')} ${log.executionTime}ms`;
+// };
+
+// const processFunction = (func, options) => {
+//   try {
+//     return logHandler[func.status](func, options);
+//   } catch (e) {
+//     logger.error(`Unable to process log ${JSON.stringify(func)}`);
+//   }
+// };
+
+const processOutput = (resp, options) => {
+  console.log('Process output: ', resp, options);
+  // if (!resp || (resp.results && !resp.results.length)) {
+  //   return 'No functions found.';
+  // } else if (resp.results && resp.results.length) {
+  //   return resp.results
+  //     .map(func => {
+  //       return processFunction(func, options);
+  //     })
+  //     .join('\n');
+  // }
+  // return processFunction(resp, options);
+};
+
+const outputFunctions = (resp, options) => {
+  logger.log(processOutput(resp, options));
+};
+
+module.exports = {
+  outputFunctions,
+};


### PR DESCRIPTION
## Description and Context
Adds `hs functions list` command that will output information about currently deployed functions.
Related to #288 

## Screenshots
`hs functions list`
![image](https://user-images.githubusercontent.com/6472448/95885064-d22f7a80-0d4a-11eb-8977-77d287c3b09e.png)

`hs functions list --compact`
![image](https://user-images.githubusercontent.com/6472448/95884924-b2985200-0d4a-11eb-8e4b-f40666a1a5ac.png)

`hs functions list --json`
![image](https://user-images.githubusercontent.com/6472448/95630535-09064780-0a50-11eb-85bb-b52f5797fbda.png)

## TODO
- ~Determine if we want to include a URL for the function or not~ Removed URL to keep this MVP
  - ~If we do want to include this, we will need the `content` scope on the personalaccesskey to obtain the `domain`~
- Have `/routes` endpoint updated to allow external auth on production before release
