### PR TITLE
hs ls command to check contents of directories

### DIFF
--- a/packages/cms-cli/bin/cli.js
+++ b/packages/cms-cli/bin/cli.js
@@ -22,6 +22,7 @@ const fetchCommand = require('../commands/fetch');
 const filemanagerCommand = require('../commands/filemanager');
 const secretsCommand = require('../commands/secrets');
 const customObjectCommand = require('../commands/customObject');
+const lsCommand = require('../commands/ls');
 
 const notifier = updateNotifier({ pkg });
 
@@ -63,6 +64,7 @@ const argv = yargs
   .command(filemanagerCommand)
   .command(secretsCommand)
   .command(customObjectCommand)
+  .command(lsCommand)
   .help()
   .recommendCommands()
   .demandCommand(1, '')

--- a/packages/cms-cli/commands/ls.js
+++ b/packages/cms-cli/commands/ls.js
@@ -1,0 +1,81 @@
+const {
+  addPortalOptions,
+  addConfigOptions,
+  setLogLevel,
+  getPortalId,
+  addUseEnvironmentOptions,
+} = require('../lib/commonOpts');
+const { trackCommandUsage } = require('../lib/usageTracking');
+const { logDebugInfo } = require('../lib/debugInfo');
+const {
+  loadConfig,
+  validateConfig,
+  checkAndWarnGitInclusion,
+} = require('@hubspot/cms-lib');
+const { logger } = require('@hubspot/cms-lib/logger');
+const {
+  logServerlessFunctionApiErrorInstance,
+  ApiErrorContext,
+} = require('@hubspot/cms-lib/errorHandlers');
+const {
+  getDirectoryContentsByPath,
+} = require('@hubspot/cms-lib/api/fileMapper');
+const { validatePortal } = require('../lib/validation');
+
+const loadAndValidateOptions = async options => {
+  setLogLevel(options);
+  logDebugInfo(options);
+  const { config: configPath } = options;
+  loadConfig(configPath, options);
+  checkAndWarnGitInclusion();
+
+  if (!(validateConfig() && (await validatePortal(options)))) {
+    process.exit(1);
+  }
+};
+
+exports.command = 'ls [path]';
+exports.describe = 'get remote contents of a directory';
+
+exports.handler = async options => {
+  loadAndValidateOptions(options);
+
+  const { path } = options;
+  const directoryPath = path || '/';
+  const portalId = getPortalId(options);
+
+  trackCommandUsage('ls', {}, portalId);
+
+  logger.debug(`Getting contents of ${directoryPath}`);
+
+  const contentsResp = await getDirectoryContentsByPath(
+    portalId,
+    directoryPath
+  ).catch(async e => {
+    await logServerlessFunctionApiErrorInstance(
+      portalId,
+      e,
+      new ApiErrorContext({ portalId, directoryPath })
+    );
+    process.exit();
+  });
+
+  if (contentsResp.children.length) {
+    logger.log(contentsResp.children.sort().join('\n'));
+  } else {
+    logger.info(`No files found in ${directoryPath}`);
+  }
+};
+
+exports.builder = yargs => {
+  yargs.positional('path', {
+    describe: 'Remote directory to list contents',
+    type: 'string',
+  });
+
+  addConfigOptions(yargs, true);
+  addPortalOptions(yargs, true);
+  addUseEnvironmentOptions(yargs, true);
+
+  return yargs;
+};

--- a/packages/cms-cli/commands/ls.js
+++ b/packages/cms-cli/commands/ls.js
@@ -22,6 +22,8 @@ const {
 } = require('@hubspot/cms-lib/api/fileMapper');
 const { validatePortal } = require('../lib/validation');
 
+const FOLDER_DOT_EXTENSIONS = ['functions'];
+
 const loadAndValidateOptions = async options => {
   setLogLevel(options);
   logDebugInfo(options);
@@ -61,7 +63,19 @@ exports.handler = async options => {
   });
 
   if (contentsResp.children.length) {
-    logger.log(contentsResp.children.sort().join('\n'));
+    const mappedContents = contentsResp.children.map(fileOrFolder => {
+      const splitName = fileOrFolder.split('.');
+
+      if (
+        splitName.length > 1 &&
+        FOLDER_DOT_EXTENSIONS.indexOf(splitName[1]) === -1
+      ) {
+        return fileOrFolder;
+      }
+
+      return `/${fileOrFolder}`;
+    });
+    logger.log(mappedContents.sort().join('\n'));
   } else {
     logger.info(`No files found in ${directoryPath}`);
   }

--- a/packages/cms-cli/commands/ls.js
+++ b/packages/cms-cli/commands/ls.js
@@ -72,6 +72,7 @@ exports.builder = yargs => {
     describe: 'Remote directory to list contents',
     type: 'string',
   });
+  yargs.example([['$0 ls'], ['$0 ls /'], ['$0 ls serverless']]);
 
   addConfigOptions(yargs, true);
   addPortalOptions(yargs, true);

--- a/packages/cms-cli/commands/ls.js
+++ b/packages/cms-cli/commands/ls.js
@@ -14,7 +14,7 @@ const {
 } = require('@hubspot/cms-lib');
 const { logger } = require('@hubspot/cms-lib/logger');
 const {
-  logServerlessFunctionApiErrorInstance,
+  logApiErrorInstance,
   ApiErrorContext,
 } = require('@hubspot/cms-lib/errorHandlers');
 const {
@@ -52,7 +52,7 @@ exports.handler = async options => {
     portalId,
     directoryPath
   ).catch(async e => {
-    await logServerlessFunctionApiErrorInstance(
+    await logApiErrorInstance(
       portalId,
       e,
       new ApiErrorContext({ portalId, directoryPath })

--- a/packages/cms-lib/api/fileMapper.js
+++ b/packages/cms-lib/api/fileMapper.js
@@ -205,6 +205,19 @@ async function trackUsage(eventName, eventClass, meta = {}, portalId) {
   return http.request.post(requestOptions);
 }
 
+/**
+ * Get directory contents
+ *
+ * @async
+ * @param {string} path
+ * @returns {Promise}
+ */
+async function getDirectoryContentsByPath(portalId, path) {
+  return http.get(portalId, {
+    uri: `${FILE_MAPPER_API_PATH}/meta/${path}`,
+  });
+}
+
 module.exports = {
   deleteFile,
   deleteFolder,
@@ -215,4 +228,5 @@ module.exports = {
   trackUsage,
   upload,
   createFileMapperNodeFromStreamResponse,
+  getDirectoryContentsByPath,
 };


### PR DESCRIPTION
## Description and Context
New command `hs ls [path]` allows listing directory contents by path. Default path is root.

## Screenshots
![image](https://user-images.githubusercontent.com/6472448/95618412-00efdd00-0a3b-11eb-91aa-e9ed5847953e.png)

![image](https://user-images.githubusercontent.com/6472448/95618709-86738d00-0a3b-11eb-8b45-ea2607d6ba1a.png)

![image](https://user-images.githubusercontent.com/6472448/95618491-2846aa00-0a3b-11eb-89dd-7481c0d7bb10.png)

### Questions
Do we want to group folders/files and output folders first(perhaps with `/` prefix)?
Any other changes to the output(I made this as MVP as possible for now)?
Do we want to look at the BE endpoint to increase speed(it's a bit slow ATM)?

## Who to Notify
/cc @TheWebTech 
