### PR TITLE
Support loading the config relative to a specified directory

### DIFF
--- a/packages/cms-lib/index.js
+++ b/packages/cms-lib/index.js
@@ -5,10 +5,12 @@ const {
   getConfig,
   getPortalId,
   getPortalConfig,
+  findConfig,
   loadConfig,
   loadConfigFromEnvironment,
   updatePortalConfig,
   validateConfig,
+  isTrackingAllowed,
 } = require('./lib/config');
 const { uploadFolder } = require('./lib/uploadFolder');
 const { watch } = require('./lib/watch');
@@ -21,6 +23,7 @@ module.exports = {
   checkAndWarnGitInclusion,
   getAndLoadConfigIfNeeded,
   getConfig,
+  findConfig,
   loadConfig,
   loadConfigFromEnvironment,
   getPortalConfig,
@@ -28,6 +31,7 @@ module.exports = {
   updatePortalConfig,
   uploadFolder,
   validateConfig,
+  isTrackingAllowed,
   watch,
   walk,
 };

--- a/packages/cms-lib/lib/config.js
+++ b/packages/cms-lib/lib/config.js
@@ -351,15 +351,16 @@ const getAndLoadConfigIfNeeded = (options = {}) => {
 };
 
 const getConfigPath = path => {
-  return (
-    path ||
-    findup(
-      [
-        DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
-        DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME.replace('.yml', '.yaml'),
-      ],
-      { cwd: getCwd() }
-    )
+  return path || findConfig(getCwd());
+};
+
+const findConfig = directory => {
+  return findup(
+    [
+      DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME,
+      DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME.replace('.yml', '.yaml'),
+    ],
+    { cwd: directory }
   );
 };
 
@@ -668,6 +669,7 @@ module.exports = {
   setConfig,
   setConfigPath,
   loadConfig,
+  findConfig,
   loadConfigFromEnvironment,
   getPortalConfig,
   getPortalId,


### PR DESCRIPTION
## Description and Context

VS Code is built using electron and electron always returns `/` as the CWD when `process.cwd()` is run. This will allow us to control where to start looking for the the config file.

See https://github.com/HubSpot/hubspot-cms-vscode/pull/83 and https://github.com/electron/electron/issues/2108