### PR TITLE
Improved output of hs functions list command by using table

### DIFF
--- a/packages/cms-cli/lib/links.js
+++ b/packages/cms-cli/lib/links.js
@@ -2,9 +2,9 @@ const { getEnv } = require('@hubspot/cms-lib/lib/config');
 const { ENVIRONMENTS } = require('@hubspot/cms-lib/lib/constants');
 const { getHubSpotWebsiteOrigin } = require('@hubspot/cms-lib/lib/urls');
 const { logger } = require('@hubspot/cms-lib/logger');
-const chalk = require('chalk');
-const { table, getBorderCharacters } = require('table');
+
 const open = require('open');
+const { getTableContents, getTableHeader } = require('./table');
 
 const logSiteLinks = portalId => {
   const linksAsArray = getSiteLinksAsArray(portalId).map(l => [
@@ -13,14 +13,9 @@ const logSiteLinks = portalId => {
     l.url,
   ]);
 
-  linksAsArray.unshift([chalk.bold('Shortcut'), '', chalk.bold('Url')]);
+  linksAsArray.unshift(getTableHeader(['Shortcut', '', 'Url']));
 
-  const tableConfig = {
-    singleLine: true,
-    border: getBorderCharacters(`void`),
-  };
-
-  logger.log(table(linksAsArray, tableConfig));
+  logger.log(getTableContents(linksAsArray));
 };
 
 const getSiteLinksAsArray = portalId =>

--- a/packages/cms-cli/lib/table.js
+++ b/packages/cms-cli/lib/table.js
@@ -1,0 +1,23 @@
+const chalk = require('chalk');
+const { table, getBorderCharacters } = require('table');
+
+const tableConfigDefaults = {
+  singleLine: true,
+  border: getBorderCharacters(`void`),
+};
+
+const getTableContents = (
+  tableData = [],
+  tableConfig = tableConfigDefaults
+) => {
+  return table(tableData, tableConfig);
+};
+
+const getTableHeader = headerItems => {
+  return headerItems.map(headerItem => chalk.bold(headerItem));
+};
+
+module.exports = {
+  getTableContents,
+  getTableHeader,
+};

--- a/packages/cms-lib/lib/functions.js
+++ b/packages/cms-lib/lib/functions.js
@@ -7,8 +7,8 @@ const getFunctionArrays = resp => {
       route,
       method,
       secretNames.join(', '),
-      `${created} (${moment(created).format()})`,
-      `${updated} (${moment(updated).format()})`,
+      moment(created).format(),
+      moment(updated).format(),
     ];
   });
 };

--- a/packages/cms-lib/lib/functions.js
+++ b/packages/cms-lib/lib/functions.js
@@ -8,7 +8,7 @@ const getFunctionArrays = resp => {
       method,
       secretNames.join(', '),
       `${created} (${moment(created).format()})`,
-      `${updated}(${moment(updated).format()})`,
+      `${updated} (${moment(updated).format()})`,
     ];
   });
 };

--- a/packages/cms-lib/lib/functions.js
+++ b/packages/cms-lib/lib/functions.js
@@ -1,62 +1,18 @@
 const moment = require('moment');
-const util = require('util');
 
-const { logger } = require('../logger');
-
-const formatCompactOutput = func => {
-  return `${func.method}\t/${func.route}`;
-};
-
-const formatFullOutput = func => {
-  return `/${func.route}\nMethod: ${func.method}\nSecrets: ${util.inspect(
-    func.secretNames,
-    {
-      colors: true,
-      compact: true,
-      depth: 'Infinity',
-    }
-  )}\nCreated: ${func.created} (${moment(func.created).format()})\nUpdated: ${
-    func.updated
-  } (${moment(func.updated).format()})\n`;
-};
-
-const formatFunctionOutput = (func, options) => {
-  if (options.compact) {
-    return formatCompactOutput(func);
-  }
-
-  return formatFullOutput(func);
-};
-
-const processFunction = (func, options) => {
-  try {
-    return formatFunctionOutput(func, options);
-  } catch (e) {
-    logger.error(`Unable to process log ${JSON.stringify(func)}`);
-  }
-};
-
-const processOutput = (resp, options) => {
-  if (!resp || (resp.objects && !resp.objects.length)) {
-    return 'No functions found.';
-  } else if (resp.objects && resp.objects.length) {
-    return resp.objects
-      .map(func => {
-        return processFunction(func, options);
-      })
-      .join('\n');
-  }
-  return processFunction(resp, options);
-};
-
-const outputFunctions = (resp, options) => {
-  if (options.json) {
-    return logger.log(resp.objects);
-  }
-
-  return logger.log(processOutput(resp, options));
+const getFunctionArrays = resp => {
+  return resp.objects.map(func => {
+    const { route, method, created, updated, secretNames } = func;
+    return [
+      route,
+      method,
+      secretNames.join(', '),
+      `${created} (${moment(created).format()})`,
+      `${updated}(${moment(updated).format()})`,
+    ];
+  });
 };
 
 module.exports = {
-  outputFunctions,
+  getFunctionArrays,
 };


### PR DESCRIPTION
## Description and Context
Improves output of `hs functions list` command(https://github.com/HubSpot/hubspot-cms-tools/pull/352) by utilizing `table` dependency.

- Creates `@hubspot/cms-cli/lib/table.js` with helper methods for using table output
- Refactors `hs open` command to use helpers
- Refactors `hs functions list` to use helpers
- Removes `--compact` option from `hs functions list` command as it is no longer much use

### Before
`hs functions list`
![image](https://user-images.githubusercontent.com/6472448/95885064-d22f7a80-0d4a-11eb-8977-77d287c3b09e.png)

`hs functions list --compact`
![image](https://user-images.githubusercontent.com/6472448/95884924-b2985200-0d4a-11eb-8e4b-f40666a1a5ac.png)

### After
![image](https://user-images.githubusercontent.com/6472448/96622592-251fa980-12d8-11eb-8e06-a9857d3283b0.png)


## Who to Notify
@abelb -- any feedback on this?
@williamspiro 