### PR TITLE
Added rename event to watch that keeps revision history for renamed files

### DIFF
--- a/packages/cms-cli/commands/list.js
+++ b/packages/cms-cli/commands/list.js
@@ -1,16 +1,5 @@
 const chalk = require('chalk');
 const {
-  addPortalOptions,
-  addConfigOptions,
-  setLogLevel,
-  getPortalId,
-  addUseEnvironmentOptions,
-} = require('../lib/commonOpts');
-const { trackCommandUsage } = require('../lib/usageTracking');
-const { logDebugInfo } = require('../lib/debugInfo');
-const { validatePortal } = require('../lib/validation');
-const { isPathFolder } = require('../lib/filesystem');
-const {
   loadConfig,
   validateConfig,
   checkAndWarnGitInclusion,
@@ -27,6 +16,17 @@ const {
   HUBSPOT_FOLDER,
   MARKETPLACE_FOLDER,
 } = require('@hubspot/cms-lib/lib/constants');
+const { isFolder } = require('@hubspot/cms-lib/path');
+const {
+  addPortalOptions,
+  addConfigOptions,
+  setLogLevel,
+  getPortalId,
+  addUseEnvironmentOptions,
+} = require('../lib/commonOpts');
+const { trackCommandUsage } = require('../lib/usageTracking');
+const { logDebugInfo } = require('../lib/debugInfo');
+const { validatePortal } = require('../lib/validation');
 
 const loadAndValidateOptions = async options => {
   setLogLevel(options);
@@ -68,7 +68,7 @@ exports.handler = async options => {
 
   if (contentsResp.children.length) {
     const mappedContents = contentsResp.children.map(fileOrFolder => {
-      if (!isPathFolder(fileOrFolder)) {
+      if (!isFolder(fileOrFolder)) {
         return fileOrFolder;
       }
 

--- a/packages/cms-cli/commands/mv.js
+++ b/packages/cms-cli/commands/mv.js
@@ -9,6 +9,7 @@ const {
   logApiErrorInstance,
   ApiErrorContext,
 } = require('@hubspot/cms-lib/errorHandlers');
+const { isFolder } = require('@hubspot/cms-lib/path');
 
 const {
   addConfigOptions,
@@ -20,7 +21,6 @@ const {
 const { logDebugInfo } = require('../lib/debugInfo');
 const { validatePortal } = require('../lib/validation');
 const { trackCommandUsage } = require('../lib/usageTracking');
-const { isPathFolder } = require('../lib/filesystem');
 
 const loadAndValidateOptions = async options => {
   setLogLevel(options);
@@ -35,7 +35,7 @@ const loadAndValidateOptions = async options => {
 };
 
 const getCorrectedDestPath = (srcPath, destPath) => {
-  if (!isPathFolder(srcPath)) {
+  if (!isFolder(srcPath)) {
     return destPath;
   }
 

--- a/packages/cms-cli/lib/filesystem.js
+++ b/packages/cms-cli/lib/filesystem.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const { getCwd } = require('@hubspot/cms-lib/path');
-const { FOLDER_DOT_EXTENSIONS } = require('@hubspot/cms-lib/lib/constants');
 
 function resolveLocalPath(filepath) {
   return filepath && typeof filepath === 'string'
@@ -9,22 +8,6 @@ function resolveLocalPath(filepath) {
       getCwd();
 }
 
-function isPathFolder(path) {
-  const splitPath = path.split('/');
-  const fileOrFolderName = splitPath[splitPath.length - 1];
-  const splitName = fileOrFolderName.split('.');
-
-  if (
-    splitName.length > 1 &&
-    FOLDER_DOT_EXTENSIONS.indexOf(splitName[1]) === -1
-  ) {
-    return false;
-  }
-
-  return true;
-}
-
 module.exports = {
   resolveLocalPath,
-  isPathFolder,
 };

--- a/packages/cms-lib/api/fileMapper.js
+++ b/packages/cms-lib/api/fileMapper.js
@@ -215,8 +215,12 @@ async function trackUsage(eventName, eventClass, meta = {}, portalId) {
  * @returns {Promise}
  */
 async function moveFile(portalId, srcPath, destPath) {
+  console.log('moveFile: ', srcPath, destPath);
+  const src = srcPath[0] === '/' ? srcPath.slice(1) : srcPath;
+  const dest = destPath[0] === '/' ? destPath.slice(1) : destPath;
+
   return http.put(portalId, {
-    uri: `${FILE_MAPPER_API_PATH}/rename/${srcPath}?path=${destPath}`,
+    uri: `${FILE_MAPPER_API_PATH}/rename/${src}?path=${dest}`,
   });
 }
 

--- a/packages/cms-lib/lib/watch.js
+++ b/packages/cms-lib/lib/watch.js
@@ -218,14 +218,24 @@ function watch(
       return;
     }
 
-    logger.debug('Attempting to move %s "%s"', type, remoteSrc);
+    logger.debug(
+      'Attempting to move %s "%s" to "%s"',
+      type,
+      remoteSrc,
+      remoteDest
+    );
     queue.add(() => {
       const deletePromise = moveFile(portalId, remoteSrc, remoteDest)
         .then(() => {
-          logger.log('Moved %s "%s"', type, remoteSrc);
+          logger.log('Moved %s "%s" to "%s"', type, remoteSrc, remoteDest);
         })
         .catch(error => {
-          logger.error('Moving %s "%s" failed', type, remoteSrc);
+          logger.error(
+            'Moving %s "%s" to "%s" failed',
+            type,
+            remoteSrc,
+            remoteDest
+          );
           logApiErrorInstance(
             error,
             new ApiErrorContext({

--- a/packages/cms-lib/lib/watch.js
+++ b/packages/cms-lib/lib/watch.js
@@ -129,10 +129,11 @@ function watch(
     logger.log(`Watcher is ready and watching ${src}`);
   });
 
-  watcher.on('add', async filePath => {
+  watcher.on('add', filePath => {
     console.log('add event', filePath);
 
     if (checkIfWasMoved(filePath)) {
+      console.log('short circuiting add', path, checkIfWasMoved(path));
       return;
     }
 
@@ -145,7 +146,7 @@ function watch(
   });
 
   if (remove) {
-    const deleteFileOrFolder = type => async filePath => {
+    const deleteFileOrFolder = type => filePath => {
       console.log('unlink/unlinkDir event');
       const remotePath = getDesignManagerPath(filePath);
 
@@ -185,7 +186,7 @@ function watch(
     watcher.on('unlinkDir', deleteFileOrFolder('folder'));
   }
 
-  watcher.on('change', async filePath => {
+  watcher.on('change', filePath => {
     const destPath = getDesignManagerPath(filePath);
     const uploadPromise = uploadFile(portalId, filePath, destPath, {
       mode,
@@ -197,12 +198,14 @@ function watch(
   const movedPaths = {};
   const rawMovedPaths = [];
 
-  const checkIfWasMoved = async function(path) {
+  const checkIfWasMoved = function(path) {
+    console.log('movedPaths', movedPaths);
     return movedPaths[path];
   };
 
-  watcher.on('raw', async (event, path) => {
+  watcher.on('raw', (event, path) => {
     if (event === 'moved') {
+      console.log('moved event', path);
       rawMovedPaths.push(path);
       movedPaths[path] = true;
 
@@ -211,7 +214,6 @@ function watch(
         watcher.emit('rename', rawMovedPaths.shift(), rawMovedPaths.shift());
       }
     }
-    // console.log('RAW: ', event, path, details);
   });
 
   function isPathFolder(path) {

--- a/packages/cms-lib/lib/watch.js
+++ b/packages/cms-lib/lib/watch.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const chokidar = require('chokidar');
 const { default: PQueue } = require('p-queue');
-const { FOLDER_DOT_EXTENSIONS } = require('@hubspot/cms-lib/lib/constants');
 
 const { logger } = require('../logger');
 const {
@@ -15,7 +14,7 @@ const { shouldIgnoreFile, ignoreFile } = require('../ignoreRules');
 const { getFileMapperApiQueryFromMode } = require('../fileMapper');
 const { upload, deleteFile, moveFile } = require('../api/fileMapper');
 const escapeRegExp = require('./escapeRegExp');
-const { convertToUnixPath, isAllowedExtension } = require('../path');
+const { convertToUnixPath, isAllowedExtension, isFolder } = require('../path');
 const { triggerNotify } = require('./notify');
 
 const queue = new PQueue({
@@ -216,28 +215,13 @@ function watch(
     }
   });
 
-  function isPathFolder(path) {
-    const splitPath = path.split('/');
-    const fileOrFolderName = splitPath[splitPath.length - 1];
-    const splitName = fileOrFolderName.split('.');
-
-    if (
-      splitName.length > 1 &&
-      FOLDER_DOT_EXTENSIONS.indexOf(splitName[1]) === -1
-    ) {
-      return false;
-    }
-
-    return true;
-  }
-
   watcher.on('rename', (srcPath, destPath) => {
     console.log('rename event', srcPath, destPath);
     const remoteSrc = getDesignManagerPath(srcPath);
     const remoteDest = getDesignManagerPath(destPath);
     console.log('remoteSrc', remoteSrc);
     console.log('remoteDest', remoteDest);
-    const type = isPathFolder(srcPath) ? 'folder' : 'file';
+    const type = isFolder(srcPath) ? 'folder' : 'file';
 
     if (shouldIgnoreFile(srcPath, cwd)) {
       logger.debug(`Skipping ${srcPath} due to an ignore rule`);

--- a/packages/cms-lib/lib/watch.js
+++ b/packages/cms-lib/lib/watch.js
@@ -129,10 +129,7 @@ function watch(
   });
 
   watcher.on('add', filePath => {
-    console.log('add event', filePath);
-
     if (checkIfWasMoved(filePath)) {
-      console.log('short circuiting add', path, checkIfWasMoved(path));
       return;
     }
 
@@ -146,7 +143,6 @@ function watch(
 
   if (remove) {
     const deleteFileOrFolder = type => filePath => {
-      console.log('unlink/unlinkDir event');
       const remotePath = getDesignManagerPath(filePath);
 
       if (checkIfWasMoved(filePath)) {
@@ -198,29 +194,23 @@ function watch(
   const rawMovedPaths = [];
 
   const checkIfWasMoved = function(path) {
-    console.log('movedPaths', movedPaths);
     return movedPaths[path];
   };
 
   watcher.on('raw', (event, path) => {
     if (event === 'moved') {
-      console.log('moved event', path);
       rawMovedPaths.push(path);
       movedPaths[path] = true;
 
       if (rawMovedPaths.length >= 2) {
-        console.log('emitting rename');
         watcher.emit('rename', rawMovedPaths.shift(), rawMovedPaths.shift());
       }
     }
   });
 
   watcher.on('rename', (srcPath, destPath) => {
-    console.log('rename event', srcPath, destPath);
     const remoteSrc = getDesignManagerPath(srcPath);
     const remoteDest = getDesignManagerPath(destPath);
-    console.log('remoteSrc', remoteSrc);
-    console.log('remoteDest', remoteDest);
     const type = isFolder(srcPath) ? 'folder' : 'file';
 
     if (shouldIgnoreFile(srcPath, cwd)) {
@@ -243,6 +233,10 @@ function watch(
               request: remoteSrc,
             })
           );
+        })
+        .finally(() => {
+          delete movedPaths[srcPath];
+          delete movedPaths[destPath];
         });
       triggerNotify(notify, 'Moved', srcPath, deletePromise);
       return deletePromise;

--- a/packages/cms-lib/path.js
+++ b/packages/cms-lib/path.js
@@ -1,6 +1,9 @@
 const path = require('path');
 const unixify = require('unixify');
-const { ALLOWED_EXTENSIONS } = require('./lib/constants');
+const {
+  ALLOWED_EXTENSIONS,
+  FOLDER_DOT_EXTENSIONS,
+} = require('./lib/constants');
 
 const convertToUnixPath = _path => {
   return unixify(path.normalize(_path));
@@ -96,6 +99,21 @@ const isAllowedExtension = filepath => {
 
 const getAbsoluteFilePath = _path => path.resolve(getCwd(), _path);
 
+function isFolder(path) {
+  const splitPath = path.split('/');
+  const fileOrFolderName = splitPath[splitPath.length - 1];
+  const splitName = fileOrFolderName.split('.');
+
+  if (
+    splitName.length > 1 &&
+    FOLDER_DOT_EXTENSIONS.indexOf(splitName[1]) === -1
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
 module.exports = {
   convertToUnixPath,
   convertToWindowsPath,
@@ -105,6 +123,7 @@ module.exports = {
   getCwd,
   getExt,
   isAllowedExtension,
+  isFolder,
   splitHubSpotPath,
   splitLocalPath,
 };


### PR DESCRIPTION
## Description and Context
When renaming/moving files currently being watched, there is a `deleteRemoteFile` and subsequent `uploadFile` that is performed, which causes the revision history to be lost for the file.

This PR looks to modify the watch command to use a new endpoint that will retain the revision history when a file/folder is renamed.

## TODO
Add a bunch of unit tests.

## Who to Notify
@williamspiro 