### PR TITLE
Fix log tailing

### DIFF
--- a/packages/cms-lib/api/results.js
+++ b/packages/cms-lib/api/results.js
@@ -3,12 +3,13 @@ const http = require('../http');
 const RESULTS_API_PATH = 'cms/v3/functions/results';
 
 async function getFunctionLogs(portalId, functionId, query = {}) {
-  const { limit = 5 } = query;
+  const { limit = 5, after } = query;
 
   return http.get(portalId, {
     uri: `${RESULTS_API_PATH}/${functionId}`,
     query: {
       limit,
+      after,
     },
   });
 }

--- a/packages/cms-lib/api/results.js
+++ b/packages/cms-lib/api/results.js
@@ -3,14 +3,11 @@ const http = require('../http');
 const RESULTS_API_PATH = 'cms/v3/functions/results';
 
 async function getFunctionLogs(portalId, functionId, query = {}) {
-  const { limit = 5, after } = query;
+  const { limit = 5 } = query;
 
   return http.get(portalId, {
     uri: `${RESULTS_API_PATH}/${functionId}`,
-    query: {
-      limit,
-      after,
-    },
+    query: { ...query, limit },
   });
 }
 


### PR DESCRIPTION
## Description and Context
Fixes #378 
There were two issues preventing logs from displaying properly:
1. The first call to get the latest log result was improperly returning the first result (API has been fixed)
2. The paging `after` token was not getting passed while polling for results, which caused the first 5 results to return each time.