### PR TITLE
Fix filemanger fetch error

### DIFF
--- a/packages/cms-lib/fileManager.js
+++ b/packages/cms-lib/fileManager.js
@@ -156,7 +156,6 @@ async function fetchAllPagedFiles(accountId, folderId, { includeArchived }) {
 async function fetchFolderContents(accountId, folder, dest, options) {
   try {
     await fs.ensureDir(dest);
-    logger.log('Wrote folder "%s"', dest);
   } catch (err) {
     logFileSystemErrorInstance(
       err,


### PR DESCRIPTION
## Description and Context
While tracking down another bug, I found that the filemanger fetch command was failing when fetching folders due to a change in #339 that moved the logic for creating writeStreams and it looks like I missed updating this command as well.