### PR TITLE
Filemanager v3 api

### DIFF
--- a/packages/cms-lib/api/fileManager.js
+++ b/packages/cms-lib/api/fileManager.js
@@ -2,7 +2,8 @@ const fs = require('fs');
 const path = require('path');
 const http = require('../http');
 
-const FILE_MANAGER_API_PATH = 'filemanager/api/v2';
+const FILE_MANAGER_V2_API_PATH = 'filemanager/api/v2';
+const FILE_MANAGER_V3_API_PATH = 'filemanager/api/v3';
 
 async function uploadFile(accountId, src, dest) {
   const directory = path.dirname(dest);
@@ -17,7 +18,7 @@ async function uploadFile(accountId, src, dest) {
   }
 
   return http.post(accountId, {
-    uri: `${FILE_MANAGER_API_PATH}/files`,
+    uri: `${FILE_MANAGER_V3_API_PATH}/files`,
     qs: {
       overwrite: 'true',
     },
@@ -27,13 +28,13 @@ async function uploadFile(accountId, src, dest) {
 
 async function fetchStat(accountId, src) {
   return http.get(accountId, {
-    uri: `${FILE_MANAGER_API_PATH}/files/stat/${src}`,
+    uri: `${FILE_MANAGER_V2_API_PATH}/files/stat/${src}`,
   });
 }
 
 async function fetchFiles(accountId, folderId, { offset, archived }) {
   return http.get(accountId, {
-    uri: `${FILE_MANAGER_API_PATH}/files/`,
+    uri: `${FILE_MANAGER_V2_API_PATH}/files/`,
     qs: {
       hidden: 0,
       offset: offset,
@@ -45,7 +46,7 @@ async function fetchFiles(accountId, folderId, { offset, archived }) {
 
 async function fetchFolders(accountId, folderId) {
   return http.get(accountId, {
-    uri: `${FILE_MANAGER_API_PATH}/folders/`,
+    uri: `${FILE_MANAGER_V2_API_PATH}/folders/`,
     qs: {
       hidden: 0,
       parent_folder_id: folderId || 'None',

--- a/packages/cms-lib/api/fileManager.js
+++ b/packages/cms-lib/api/fileManager.js
@@ -10,18 +10,19 @@ async function uploadFile(accountId, src, dest) {
   const filename = path.basename(dest);
   const formData = {
     file: fs.createReadStream(src),
-    file_names: filename,
+    fileName: filename,
+    options: JSON.stringify({
+      access: 'PUBLIC_INDEXABLE',
+      overwrite: true,
+    }),
   };
 
   if (directory && directory !== '.' && directory !== '/') {
-    formData.folder_paths = directory;
+    formData.folderPath = directory;
   }
 
   return http.post(accountId, {
-    uri: `${FILE_MANAGER_V3_API_PATH}/files`,
-    qs: {
-      overwrite: 'true',
-    },
+    uri: `${FILE_MANAGER_V3_API_PATH}/files/upload`,
     formData,
   });
 }


### PR DESCRIPTION
## Description and Context
There was an update to the filemanager api where APIKEY access was revoked from uploads with the v2 endpoints. It was advised to update the upload enpoint to v3 (which does allow APIKEY) and to keep using v2 for requests that involve fetching files because the v3 API currently does not offer the same endpoints for managing files by path


This was reported in the Developer Slack https://hubspotdev.slack.com/archives/CLJJXGTC0/p1605198690210500
