### PR TITLE
Fix bug when fetching filemanger to `./`

### DIFF
--- a/packages/cms-lib/api/fileManager.js
+++ b/packages/cms-lib/api/fileManager.js
@@ -37,7 +37,7 @@ async function fetchFiles(accountId, folderId, { offset, archived }) {
     qs: {
       hidden: 0,
       offset: offset,
-      folder_id: folderId || 'None',
+      folder_id: folderId,
       ...(!archived && { archived: 0 }),
     },
   });
@@ -48,7 +48,7 @@ async function fetchFolders(accountId, folderId) {
     uri: `${FILE_MANAGER_API_PATH}/folders/`,
     qs: {
       hidden: 0,
-      parent_folder_id: folderId || 'None',
+      parent_folder_id: folderId,
     },
   });
 }

--- a/packages/cms-lib/fileManager.js
+++ b/packages/cms-lib/fileManager.js
@@ -187,19 +187,23 @@ async function fetchFolderContents(accountId, folder, dest, options) {
  */
 async function downloadFolder(accountId, src, dest, folder, options) {
   try {
-    let rootPath = dest;
+    let absolutePath;
 
-    if (dest === getCwd() && folder.name) {
-      rootPath = convertToLocalFileSystemPath(path.resolve(dest, folder.name));
+    if (folder.name) {
+      absolutePath = convertToLocalFileSystemPath(
+        path.resolve(getCwd(), dest, folder.name)
+      );
+    } else {
+      absolutePath = convertToLocalFileSystemPath(path.resolve(getCwd(), dest));
     }
 
     logger.log(
       'Fetching folder from "%s" to "%s" in the File Manager of account %s',
       src,
-      rootPath,
+      absolutePath,
       accountId
     );
-    await fetchFolderContents(accountId, folder, rootPath, options);
+    await fetchFolderContents(accountId, folder, absolutePath, options);
     logger.success(
       'Completed fetch of folder "%s" to "%s" from the File Manager',
       src,
@@ -261,7 +265,7 @@ async function downloadSingleFile(accountId, src, dest, file, options) {
 async function downloadFileOrFolder(accountId, src, dest, options) {
   try {
     if (src == '/') {
-      const rootFolder = { id: 'None', name: '/' };
+      const rootFolder = { id: 'None' };
       await downloadFolder(accountId, src, dest, rootFolder, options);
     } else {
       const { file, folder } = await fetchStat(accountId, src);

--- a/packages/cms-lib/fileManager.js
+++ b/packages/cms-lib/fileManager.js
@@ -103,7 +103,6 @@ async function downloadFile(accountId, file, dest, options) {
   if (await skipExisting(options.overwrite, destPath)) {
     return;
   }
-
   try {
     await http.getOctetStream(
       accountId,
@@ -113,7 +112,6 @@ async function downloadFile(accountId, file, dest, options) {
       },
       destPath
     );
-    logger.log(`Wrote file "${destPath}"`);
   } catch (err) {
     logErrorInstance(err);
   }
@@ -261,26 +259,26 @@ async function downloadSingleFile(accountId, src, dest, file, options) {
  * @param {object} options
  */
 async function downloadFileOrFolder(accountId, src, dest, options) {
-  if (src === '/') {
-    await downloadFolder(accountId, src, dest, '', options);
-  } else {
-    try {
+  try {
+    if (src == '/') {
+      const rootFolder = { id: 'None', name: '/' };
+      await downloadFolder(accountId, src, dest, rootFolder, options);
+    } else {
       const { file, folder } = await fetchStat(accountId, src);
-
       if (file) {
-        downloadSingleFile(accountId, src, dest, file, options);
+        await downloadSingleFile(accountId, src, dest, file, options);
       } else if (folder) {
-        downloadFolder(accountId, src, dest, folder, options);
+        await downloadFolder(accountId, src, dest, folder, options);
       }
-    } catch (err) {
-      logApiErrorInstance(
-        err,
-        new ApiErrorContext({
-          request: src,
-          accountId,
-        })
-      );
     }
+  } catch (err) {
+    logApiErrorInstance(
+      err,
+      new ApiErrorContext({
+        request: src,
+        accountId,
+      })
+    );
   }
 }
 

--- a/packages/cms-lib/fileManager.js
+++ b/packages/cms-lib/fileManager.js
@@ -265,6 +265,7 @@ async function downloadSingleFile(accountId, src, dest, file, options) {
 async function downloadFileOrFolder(accountId, src, dest, options) {
   try {
     if (src == '/') {
+      // Filemanager API treats 'None' as the root
       const rootFolder = { id: 'None' };
       await downloadFolder(accountId, src, dest, rootFolder, options);
     } else {

--- a/packages/cms-lib/fileManager.js
+++ b/packages/cms-lib/fileManager.js
@@ -189,10 +189,12 @@ async function fetchFolderContents(accountId, folder, dest, options) {
  */
 async function downloadFolder(accountId, src, dest, folder, options) {
   try {
-    const rootPath =
-      dest === getCwd()
-        ? convertToLocalFileSystemPath(path.resolve(dest, folder.name))
-        : dest;
+    let rootPath = dest;
+
+    if (dest === getCwd() && folder.name) {
+      rootPath = convertToLocalFileSystemPath(path.resolve(dest, folder.name));
+    }
+
     logger.log(
       'Fetching folder from "%s" to "%s" in the File Manager of account %s',
       src,

--- a/packages/cms-lib/fileManager.js
+++ b/packages/cms-lib/fileManager.js
@@ -184,7 +184,7 @@ async function fetchFolderContents(accountId, folder, dest, options) {
  * @param {number} accountId
  * @param {string} src
  * @param {string} dest
- * @param {object} file
+ * @param {object} folder
  * @param {object} options
  */
 async function downloadFolder(accountId, src, dest, folder, options) {

--- a/packages/cms-lib/http.js
+++ b/packages/cms-lib/http.js
@@ -150,8 +150,11 @@ const createGetRequestStream = ({ contentType }) => async (
       req.on('error', reject);
       req.on('response', res => {
         if (res.statusCode >= 200 && res.statusCode < 300) {
-          fs.ensureFileSync(filepath);
-
+          try {
+            fs.ensureFileSync(filepath);
+          } catch (err) {
+            reject(err);
+          }
           const writeStream = fs.createWriteStream(filepath, {
             encoding: 'binary',
           });

--- a/packages/cms-lib/http.js
+++ b/packages/cms-lib/http.js
@@ -150,6 +150,8 @@ const createGetRequestStream = ({ contentType }) => async (
       req.on('error', reject);
       req.on('response', res => {
         if (res.statusCode >= 200 && res.statusCode < 300) {
+          fs.ensureFileSync(filepath);
+
           const writeStream = fs.createWriteStream(filepath, {
             encoding: 'binary',
           });


### PR DESCRIPTION
## Description and Context
A developer in the HS Slack community discovered an issue where you could not download all filemanager files to the current working directory (`./`). When constructing a local path, if the folder name argument wasn't passed, it failed.
