### PR TITLE
Added delete option to hs functions deploy command to support BE in alpha release

### DIFF
--- a/packages/cms-lib/api/designManager.js
+++ b/packages/cms-lib/api/designManager.js
@@ -25,7 +25,14 @@ async function fetchBuiltinMapping(accountId) {
   });
 }
 
+async function fetchRawAssetByPath(accountId, path) {
+  return http.get(accountId, {
+    uri: `${DESIGN_MANAGER_API_PATH}/raw-assets/by-path/${path}?portalId=${accountId}`,
+  });
+}
+
 module.exports = {
   fetchBuiltinMapping,
   fetchMenus,
+  fetchRawAssetByPath,
 };

--- a/packages/cms-lib/api/functions.js
+++ b/packages/cms-lib/api/functions.js
@@ -1,4 +1,5 @@
 const http = require('../http');
+const { fetchRawAssetByPath } = require('./designManager');
 
 const FUNCTION_API_PATH = 'cms/v3/functions';
 
@@ -23,8 +24,17 @@ async function buildPackage(portalId, path) {
   });
 }
 
+async function deletePackage(portalId, path) {
+  return fetchRawAssetByPath(portalId, path).then(resp => {
+    return http.delete(portalId, {
+      uri: `${FUNCTION_API_PATH}/package?portalId=${portalId}&rawAssetId=${resp.id}`,
+    });
+  });
+}
+
 module.exports = {
   buildPackage,
+  deletePackage,
   getFunctionByPath,
   getRoutes,
 };


### PR DESCRIPTION
## Description and Context
Adds a `--delete` option to the `hs functions deploy <remoteDotFunctionsFolderPath>` command to manually delete the current build associated with a functions folder.

## Screenshots
![image](https://user-images.githubusercontent.com/6472448/102107901-41cfed80-3e00-11eb-8664-6033dbf1584a.png)
![image](https://user-images.githubusercontent.com/6472448/102107658-f61d4400-3dff-11eb-800d-cee21ca30aee.png)

## Who to Notify
@bkrainer 