### PR TITLE
add alwaysStat flag to ensure we have fs.Stats available.  Without it…

### DIFF
--- a/packages/cms-lib/api/fileMapper.js
+++ b/packages/cms-lib/api/fileMapper.js
@@ -1,4 +1,5 @@
-const fs = require('fs-extra');
+// We are purposely using fs instaed of fs-extra here. See https://github.com/HubSpot/hubspot-cms-tools/pull/407
+const fs = require('fs');
 const path = require('path');
 const contentDisposition = require('content-disposition');
 const http = require('../http');

--- a/packages/cms-lib/lib/watch.js
+++ b/packages/cms-lib/lib/watch.js
@@ -99,8 +99,6 @@ function watch(
   const watcher = chokidar.watch(src, {
     ignoreInitial: true,
     ignored: file => shouldIgnoreFile(file, cwd),
-    // Before removing this line, look at https://github.com/HubSpot/hubspot-cms-tools/pull/407
-    alwaysStat: true,
   });
 
   const getDesignManagerPath = file => {

--- a/packages/cms-lib/lib/watch.js
+++ b/packages/cms-lib/lib/watch.js
@@ -99,6 +99,7 @@ function watch(
   const watcher = chokidar.watch(src, {
     ignoreInitial: true,
     ignored: file => shouldIgnoreFile(file, cwd),
+    alwaysStat: true,
   });
 
   const getDesignManagerPath = file => {

--- a/packages/cms-lib/lib/watch.js
+++ b/packages/cms-lib/lib/watch.js
@@ -99,6 +99,7 @@ function watch(
   const watcher = chokidar.watch(src, {
     ignoreInitial: true,
     ignored: file => shouldIgnoreFile(file, cwd),
+    // Before removing this line, look at https://github.com/HubSpot/hubspot-cms-tools/pull/407
     alwaysStat: true,
   });
 


### PR DESCRIPTION
adding this flag provides fs.Stats is passed in since it is needed in some scenarios.  Without this, the watch command would hang on uploading for some people (myself included)