### PR TITLE
Re-enable colors, use an env var instead

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,5 @@
+process.env.FORCE_COLOR = 0;
+
 module.exports = {
   projects: ['<rootDir>/packages/*'],
   collectCoverage: true,

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,4 @@
+// Chalk can cause snapshots to with its styling, just disable the color instead
 process.env.FORCE_COLOR = 0;
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "prettier:write": "prettier --write 'packages/**/*.{js,json}'",
     "publish-release": "yarn lerna publish --conventional-graduate",
     "publish-prerelease": "yarn lerna publish prerelease --preid beta --dist-tag next",
-    "test": "jest --no-colors",
-    "jest": "jest --watch --no-colors",
+    "test": "jest",
+    "jest": "jest --watch",
     "circular-deps": "yarn madge --circular packages"
   },
   "lint-staged": {


### PR DESCRIPTION
This way it doesn't disable Jest's color output, but still doesn't do color on snapshots